### PR TITLE
#19 Use lists instead of sets for command palette and menu items

### DIFF
--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/kind/SetContextActions.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/kind/SetContextActions.java
@@ -15,30 +15,30 @@
  ******************************************************************************/
 package org.eclipse.glsp.api.action.kind;
 
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.eclipse.glsp.api.action.Action;
 import org.eclipse.glsp.api.types.LabeledAction;
 
 public class SetContextActions extends ResponseAction {
 
-   private Set<LabeledAction> actions;
+   private List<LabeledAction> actions;
    private Map<String, String> args;
 
    public SetContextActions() {
       super(Action.Kind.SET_CONTEXT_ACTIONS);
    }
 
-   public SetContextActions(final Set<LabeledAction> actions, final Map<String, String> map) {
+   public SetContextActions(final List<LabeledAction> actions, final Map<String, String> map) {
       this();
       this.actions = actions;
       this.args = map;
    }
 
-   public Set<LabeledAction> getActions() { return actions; }
+   public List<LabeledAction> getActions() { return actions; }
 
-   public void setActions(final Set<LabeledAction> commandPaletteActions) { this.actions = commandPaletteActions; }
+   public void setActions(final List<LabeledAction> commandPaletteActions) { this.actions = commandPaletteActions; }
 
    public Map<String, String> getArgs() { return args; }
 

--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/provider/CommandPaletteActionProvider.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/provider/CommandPaletteActionProvider.java
@@ -19,7 +19,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import org.eclipse.glsp.api.model.GraphicalModelState;
 import org.eclipse.glsp.api.types.LabeledAction;
@@ -32,10 +31,10 @@ public interface CommandPaletteActionProvider {
    String TEXT = "text";
    String INDEX = "index";
 
-   Set<LabeledAction> getActions(GraphicalModelState modelState, List<String> selectedElementIds,
+   List<LabeledAction> getActions(GraphicalModelState modelState, List<String> selectedElementIds,
       Optional<GPoint> lastMousePosition, Map<String, String> args);
 
-   default Set<LabeledAction> getActions(final GraphicalModelState modelState, final List<String> selectedElementIds,
+   default List<LabeledAction> getActions(final GraphicalModelState modelState, final List<String> selectedElementIds,
       final GPoint lastMousePosition, final Map<String, String> args) {
       return getActions(modelState, selectedElementIds, Optional.ofNullable(lastMousePosition), args);
    }
@@ -50,9 +49,9 @@ public interface CommandPaletteActionProvider {
 
    class NullImpl implements CommandPaletteActionProvider {
       @Override
-      public Set<LabeledAction> getActions(final GraphicalModelState modelState, final List<String> selectedElementIds,
+      public List<LabeledAction> getActions(final GraphicalModelState modelState, final List<String> selectedElementIds,
          final Optional<GPoint> lastMousePosition, final Map<String, String> args) {
-         return Collections.emptySet();
+         return Collections.emptyList();
       }
    }
 }

--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/provider/ContextMenuItemProvider.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/provider/ContextMenuItemProvider.java
@@ -19,7 +19,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import org.eclipse.glsp.api.model.GraphicalModelState;
 import org.eclipse.glsp.api.types.MenuItem;
@@ -30,19 +29,19 @@ public interface ContextMenuItemProvider {
 
    String KEY = "context-menu";
 
-   Set<MenuItem> getItems(GraphicalModelState modelState, List<String> selectedElementIds,
+   List<MenuItem> getItems(GraphicalModelState modelState, List<String> selectedElementIds,
       Optional<GPoint> lastMousePosition, Map<String, String> args);
 
-   default Set<MenuItem> getItems(final GraphicalModelState modelState, final List<String> selectedElementIds,
+   default List<MenuItem> getItems(final GraphicalModelState modelState, final List<String> selectedElementIds,
       final GPoint lastMousePosition, final Map<String, String> args) {
       return getItems(modelState, selectedElementIds, Optional.ofNullable(lastMousePosition), args);
    }
 
    class NullImpl implements ContextMenuItemProvider {
       @Override
-      public Set<MenuItem> getItems(final GraphicalModelState modelState, final List<String> selectedElementIds,
+      public List<MenuItem> getItems(final GraphicalModelState modelState, final List<String> selectedElementIds,
          final Optional<GPoint> lastMousePosition, final Map<String, String> args) {
-         return Collections.emptySet();
+         return Collections.emptyList();
       }
    }
 }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actionhandler/RequestContextActionsHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actionhandler/RequestContextActionsHandler.java
@@ -15,11 +15,10 @@
  ********************************************************************************/
 package org.eclipse.glsp.server.actionhandler;
 
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import org.eclipse.glsp.api.action.Action;
 import org.eclipse.glsp.api.action.kind.RequestContextActions;
@@ -52,7 +51,7 @@ public class RequestContextActionsHandler extends AbstractActionHandler {
          RequestContextActions requestContextAction = (RequestContextActions) action;
          List<String> selectedElementIds = requestContextAction.getSelectedElementIds();
          Map<String, String> args = requestContextAction.getArgs();
-         Set<LabeledAction> items = new HashSet<>();
+         List<LabeledAction> items = new ArrayList<>();
          if (equalsUiControl(args, CommandPaletteActionProvider.KEY)) {
             items.addAll(commandPaletteActionProvider.getActions(modelState, selectedElementIds,
                requestContextAction.getLastMousePosition(), args));


### PR DESCRIPTION
This ensures that the order is stable and allows the server to control
the order of elements in the command palette on the client.

Resolves #19