### PR TITLE
Ensure that JavaSE-1.8 is used instead of 10

### DIFF
--- a/plugins/org.eclipse.glsp.api/.classpath
+++ b/plugins/org.eclipse.glsp.api/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-10">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/plugins/org.eclipse.glsp.api/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.api/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.glsp.api
 Bundle-Version: 0.7.0.qualifier
 Bundle-Vendor: EclipseSource
 Automatic-Module-Name: org.eclipse.glsp.api
-Bundle-RequiredExecutionEnvironment: JavaSE-10
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: com.google.inject;bundle-version="3.0.0";visibility:=reexport,
  org.eclipse.lsp4j,
  org.eclipse.lsp4j.jsonrpc;bundle-version="0.6.0",

--- a/plugins/org.eclipse.glsp.graph/.classpath
+++ b/plugins/org.eclipse.glsp.graph/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-10">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/plugins/org.eclipse.glsp.graph/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.graph/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.glsp.graph;singleton:=true
 Bundle-Version: 0.7.0.qualifier
 Bundle-Vendor: EclipseSource
 Automatic-Module-Name: org.eclipse.glsp.graph
-Bundle-RequiredExecutionEnvironment: JavaSE-10
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.emf.common;bundle-version="2.15.0",
  com.google.gson,
  org.eclipse.emf.ecore;bundle-version="2.15.0";visibility:=reexport,

--- a/plugins/org.eclipse.glsp.layout/.classpath
+++ b/plugins/org.eclipse.glsp.layout/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-10"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/plugins/org.eclipse.glsp.layout/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.layout/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.glsp.layout
 Bundle-Version: 0.7.0.qualifier
 Bundle-Vendor: EclispeSource
 Automatic-Module-Name: org.eclipse.glsp.layout
-Bundle-RequiredExecutionEnvironment: JavaSE-10
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.glsp.api;bundle-version="0.7.0",
  org.eclipse.elk.core;bundle-version="0.5.0",
  org.eclipse.elk.graph;bundle-version="0.5.0",

--- a/plugins/org.eclipse.glsp.server.websocket/.classpath
+++ b/plugins/org.eclipse.glsp.server.websocket/.classpath
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="src/"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/plugins/org.eclipse.glsp.server.websocket/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.server.websocket/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.glsp.server.websocket
 Bundle-Version: 0.7.0.qualifier
 Bundle-Vendor: EclipseSource
 Automatic-Module-Name: com.eclipsesource.glps.server.websocket
-Bundle-RequiredExecutionEnvironment: JavaSE-10
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: javax.websocket;bundle-version="1.1.0";visibility:=reexport,
  javax.servlet;bundle-version="3.1.0";visibility:=reexport,
  org.eclipse.jetty.server;bundle-version="9.4.14";visibility:=reexport,

--- a/plugins/org.eclipse.glsp.server/.classpath
+++ b/plugins/org.eclipse.glsp.server/.classpath
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="src/"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/plugins/org.eclipse.glsp.server/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.server/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.glsp.server
 Bundle-Version: 0.7.0.qualifier
 Bundle-Vendor: EclipseSource
 Automatic-Module-Name: org.eclipse.glsp.server
-Bundle-RequiredExecutionEnvironment: JavaSE-10
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.glsp.api;bundle-version="0.7.0";visibility:=reexport,
  org.apache.commons.io;bundle-version="2.2.0",
  org.eclipse.emf.ecore.change;bundle-version="2.13.0",


### PR DESCRIPTION
This avoids Eclipse issues with Java10.  This also aligns the plugin configuration and the maven configuration (which uses Java 1.8 anyways)