### PR TITLE
Align snapshot version numbers

### DIFF
--- a/plugins/org.eclipse.glsp.api/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.api/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GLSP API
 Bundle-SymbolicName: org.eclipse.glsp.api
-Bundle-Version: 0.7.0.qualifier
+Bundle-Version: 0.8.0.qualifier
 Bundle-Vendor: EclipseSource
 Automatic-Module-Name: org.eclipse.glsp.api
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/plugins/org.eclipse.glsp.api/pom.xml
+++ b/plugins/org.eclipse.glsp.api/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>0.7.0-SNAPSHOT</version>
+		<version>0.8.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
@@ -79,7 +79,7 @@
 		<dependency>
 			<groupId>org.eclipse.glsp</groupId>
 			<artifactId>org.eclipse.glsp.graph</artifactId>
-			<version>0.7.0-SNAPSHOT</version>
+			<version>0.8.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.websocket</groupId>

--- a/plugins/org.eclipse.glsp.graph/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.graph/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GLSP Graph
 Bundle-SymbolicName: org.eclipse.glsp.graph;singleton:=true
-Bundle-Version: 0.7.0.qualifier
+Bundle-Version: 0.8.0.qualifier
 Bundle-Vendor: EclipseSource
 Automatic-Module-Name: org.eclipse.glsp.graph
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/plugins/org.eclipse.glsp.graph/pom.xml
+++ b/plugins/org.eclipse.glsp.graph/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>0.7.0-SNAPSHOT</version>
+		<version>0.8.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/plugins/org.eclipse.glsp.layout/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.layout/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GLSP Layout
 Bundle-SymbolicName: org.eclipse.glsp.layout
-Bundle-Version: 0.7.0.qualifier
+Bundle-Version: 0.8.0.qualifier
 Bundle-Vendor: EclispeSource
 Automatic-Module-Name: org.eclipse.glsp.layout
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/plugins/org.eclipse.glsp.layout/pom.xml
+++ b/plugins/org.eclipse.glsp.layout/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>0.7.0-SNAPSHOT</version>
+		<version>0.8.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>org.eclipse.glsp</groupId>
 			<artifactId>org.eclipse.glsp.api</artifactId>
-			<version>0.7.0-SNAPSHOT</version>
+			<version>0.8.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.elk</groupId>

--- a/plugins/org.eclipse.glsp.server.websocket/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.server.websocket/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GLSP Server Websocket
 Bundle-SymbolicName: org.eclipse.glsp.server.websocket
-Bundle-Version: 0.7.0.qualifier
+Bundle-Version: 0.8.0.qualifier
 Bundle-Vendor: EclipseSource
 Automatic-Module-Name: com.eclipsesource.glps.server.websocket
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/plugins/org.eclipse.glsp.server.websocket/pom.xml
+++ b/plugins/org.eclipse.glsp.server.websocket/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>0.7.0-SNAPSHOT</version>
+		<version>0.8.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>org.eclipse.glsp</groupId>
 			<artifactId>org.eclipse.glsp.server</artifactId>
-			<version>0.7.0-SNAPSHOT</version>
+			<version>0.8.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty.websocket</groupId>

--- a/plugins/org.eclipse.glsp.server/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.server/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GLSP Server
 Bundle-SymbolicName: org.eclipse.glsp.server
-Bundle-Version: 0.7.0.qualifier
+Bundle-Version: 0.8.0.qualifier
 Bundle-Vendor: EclipseSource
 Automatic-Module-Name: org.eclipse.glsp.server
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/plugins/org.eclipse.glsp.server/pom.xml
+++ b/plugins/org.eclipse.glsp.server/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>0.7.0-SNAPSHOT</version>
+		<version>0.8.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>org.eclipse.glsp</groupId>
 			<artifactId>org.eclipse.glsp.api</artifactId>
-			<version>0.7.0-SNAPSHOT</version>
+			<version>0.8.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>org.eclipse.glsp</groupId>
 	<artifactId>org.eclipse.glsp.parent</artifactId>
 	<description>GLSP Parent pom </description>
-	<version>0.7.0-SNAPSHOT</version>
+	<version>0.8.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>GLSP Parent</name>
@@ -53,7 +53,7 @@
 		<java.source>1.8</java.source>
 		<java.target>1.8</java.target>
 		<project.build.java.target>1.8</project.build.java.target>
-		<target.version>0.7.0-SNAPSHOT</target.version>
+		<target.version>0.8.0-SNAPSHOT</target.version>
 	</properties>
 	<build>
 		<sourceDirectory>src</sourceDirectory>
@@ -116,6 +116,7 @@
 				<module>plugins/org.eclipse.glsp.server.websocket</module>
 				<module>plugins/org.eclipse.glsp.layout</module>
 				<module>plugins/org.eclipse.glsp.graph</module>
+				<module>releng</module>
 			</modules>
 			<build>
 				<pluginManagement>

--- a/releng/org.eclipse.glsp.codestyle/pom.xml
+++ b/releng/org.eclipse.glsp.codestyle/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.eclipse.glsp</groupId>
   <artifactId>org.eclipse.glsp.releng</artifactId>
   <relativePath>../pom.xml</relativePath>
-  <version>0.7.0-SNAPSHOT</version>
+  <version>0.8.0-SNAPSHOT</version>
   </parent>
   <packaging>pom</packaging>
 </project>

--- a/releng/org.eclipse.glsp.feature/feature.xml
+++ b/releng/org.eclipse.glsp.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.glsp.feature"
       label="GLSP SDK"
-      version="0.7.0.qualifier"
+      version="0.8.0.qualifier"
       provider-name="EclipseSource">
 
    <description url="http://www.example.com/description">

--- a/releng/org.eclipse.glsp.feature/pom.xml
+++ b/releng/org.eclipse.glsp.feature/pom.xml
@@ -5,7 +5,7 @@
   <parent>
   	<groupId>org.eclipse.glsp</groupId>
   	<artifactId>org.eclipse.glsp.releng</artifactId>
-  	<version>0.7.0-SNAPSHOT</version>
+  	<version>0.8.0-SNAPSHOT</version>
   	<relativePath>../</relativePath>
   </parent>
   <packaging>eclipse-feature</packaging>

--- a/releng/org.eclipse.glsp.repository/category.xml
+++ b/releng/org.eclipse.glsp.repository/category.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature id="org.eclipse.glsp.feature" version="0.7.0.qualifier">
+   <feature id="org.eclipse.glsp.feature" version="0.8.0.qualifier">
       <category name="com.eclisesource.glsp"/>
    </feature>
-      <feature id="org.eclipse.glsp.feature.source" version="0.7.0.qualifier">
+      <feature id="org.eclipse.glsp.feature.source" version="0.8.0.qualifier">
       <category name="com.eclisesource.glsp"/>
    </feature>
-   <bundle id="org.eclipse.glsp.layout" version="0.7.0.qualifier">
+   <bundle id="org.eclipse.glsp.layout" version="0.8.0.qualifier">
       <category name="com.eclisesource.glsp"/>
    </bundle>
-   <bundle id="org.eclipse.glsp.layout.source" version="0.7.0.qualifier">
+   <bundle id="org.eclipse.glsp.layout.source" version="0.8.0.qualifier">
       <category name="com.eclisesource.glsp"/>
    </bundle>
-   <bundle id="org.eclipse.glsp.server.websocket" version="0.7.0.qualifier">
+   <bundle id="org.eclipse.glsp.server.websocket" version="0.8.0.qualifier">
       <category name="com.eclisesource.glsp"/>
    </bundle>
-   <bundle id="org.eclipse.glsp.server.websocket.source" version="0.7.0.qualifier">
+   <bundle id="org.eclipse.glsp.server.websocket.source" version="0.8.0.qualifier">
       <category name="com.eclisesource.glsp"/>
    </bundle>
    <category-def name="com.eclisesource.glsp" label="GLSP"/>

--- a/releng/org.eclipse.glsp.repository/pom.xml
+++ b/releng/org.eclipse.glsp.repository/pom.xml
@@ -5,12 +5,26 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.releng</artifactId>
-		<version>0.7.0-SNAPSHOT</version>
+		<version>0.8.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 	<artifactId>org.eclipse.glsp.repository</artifactId>
 	<packaging>eclipse-repository</packaging>
 
+	<build>
+		<plugins>
+			<!-- Skip cleaning of this module otherwise the release build is not working 
+				on the jenkins instance -->
+			<plugin>
+				<artifactId>maven-clean-plugin</artifactId>
+				<version>3.1.0</version>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+	
 	<profiles>
 		<profile>
 			<id>p2-release</id>
@@ -119,16 +133,6 @@
 							</execution>
 						</executions>
 					</plugin>
-					<!-- Skip cleaning of this module otherwise the release build is not 
-						working on the jenkins instance -->
-					<plugin>
-						<artifactId>maven-clean-plugin</artifactId>
-						<version>3.1.0</version>
-						<configuration>
-							<skip>true</skip>
-						</configuration>
-					</plugin>
-
 				</plugins>
 			</build>
 		</profile>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>0.7.0-SNAPSHOT</version>
+		<version>0.8.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 


### PR DESCRIPTION
Set version to 0.8.0 snapshot to align with glsp client packages.