### PR TITLE
Fix BasicActionHandler constructor

### DIFF
--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actionhandler/BasicActionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actionhandler/BasicActionHandler.java
@@ -26,14 +26,12 @@ import org.eclipse.glsp.api.utils.GenericsUtil;
 public abstract class BasicActionHandler<T extends Action> implements ActionHandler {
    protected final Class<T> actionType;
 
-   @SuppressWarnings("unchecked")
    public BasicActionHandler() {
-      this.actionType = (Class<T>) (GenericsUtil.getParametrizedType(getClass(), BasicActionHandler.class))
-         .getActualTypeArguments()[0];
+      this.actionType = deriveActionType();
    }
 
    @SuppressWarnings("unchecked")
-   protected Class<T> deriveOperationType() {
+   protected Class<T> deriveActionType() {
       return (Class<T>) GenericsUtil.getGenericTypeParameterClass(getClass(), BasicActionHandler.class);
    }
 

--- a/targetplatforms/r2019-12.target
+++ b/targetplatforms/r2019-12.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="2019-12 - Release" sequenceNumber="1576854484">
+<target name="2019-12 - Release" sequenceNumber="1583224617">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.2.400.v20191014-1907"/>
@@ -28,7 +28,7 @@
       <unit id="org.eclipse.elk.graph" version="0.6.0"/>
       <unit id="org.eclipse.elk.graph.text" version="0.6.0"/>
       <unit id="org.eclipse.elk.alg.layered" version="0.6.0"/>
-      <repository location="https://build.eclipse.org/modeling/elk/updates/0.6.0/"/>
+      <repository location="https://download.eclipse.org/elk/updates/releases/0.6.0/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.lsp4j" version="0.0.0"/>

--- a/targetplatforms/r2019-12.tpd
+++ b/targetplatforms/r2019-12.tpd
@@ -20,7 +20,7 @@ location "https://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.14.v2
 	org.eclipse.jetty.bundles.f.feature.group
 }
 
-location "https://build.eclipse.org/modeling/elk/updates/0.6.0/" {
+location "https://download.eclipse.org/elk/updates/releases/0.6.0/" {
 	org.eclipse.elk.core
 	org.eclipse.elk.graph
 	org.eclipse.elk.graph.text


### PR DESCRIPTION
The deriveActionType() method was not in the constructor. This is necessary to enable abstract subclasses. (similar to how it's done for `BasicOperationHandler` & `BasicCreateOperationHandler`)