### PR TITLE
Add navigation support and navigation target resolution

### DIFF
--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/Action.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/Action.java
@@ -53,6 +53,7 @@ public abstract class Action {
       public static final String REQUEST_EXPORT_SVG = "requestExportSvg";
       public static final String REQUEST_MARKERS = "requestMarkers";
       public static final String REQUEST_MODEL = "requestModel";
+      public static final String REQUEST_NAVIGATION_TARGETS = "requestNavigationTargets";
       public static final String REQUEST_OPERATIONS = "requestOperations";
       public static final String REQUEST_POPUP_MODEL = "requestPopupModel";
       public static final String REQUEST_TYPE_HINTS = "requestTypeHints";
@@ -70,6 +71,7 @@ public abstract class Action {
       public static final String SET_LAYERS = "setLayers";
       public static final String SET_MARKERS = "setMarkers";
       public static final String SET_MODEL = "setModel";
+      public static final String SET_NAVIGATION_TARGETS = "setNavigationTargets";
       public static final String SET_POPUP_MODEL = "setPopupModel";
       public static final String SET_TYPE_HINTS = "setTypeHints";
       public static final String TRIGGER_NODE_CREATION = "triggerNodeCreation";
@@ -77,5 +79,7 @@ public abstract class Action {
       public static final String UNDO = "glspUndo";
       public static final String UPDATE_MODEL = "updateModel";
       public static final String VALIDATE_LABEL_EDIT_ACTION = "validateLabelEdit";
+      public static final String RESOLVE_NAVIGATION_TARGET = "resolveNavigationTarget";
+      public static final String SET_RESOLVED_NAVIGATION_TARGET = "setResolvedNavigationTarget";
    }
 }

--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/kind/RequestNavigationTargetsAction.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/kind/RequestNavigationTargetsAction.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ******************************************************************************/
+package org.eclipse.glsp.api.action.kind;
+
+import org.eclipse.glsp.api.action.Action;
+import org.eclipse.glsp.api.types.EditorContext;
+
+public class RequestNavigationTargetsAction extends RequestAction<SetNavigationTargetsAction> {
+
+   private String targetTypeId;
+   private EditorContext editorContext;
+
+   public RequestNavigationTargetsAction() {
+      super(Action.Kind.REQUEST_NAVIGATION_TARGETS);
+   }
+
+   public RequestNavigationTargetsAction(final String targetType, final EditorContext editorContext) {
+      this();
+      this.targetTypeId = targetType;
+      this.editorContext = editorContext;
+   }
+
+   public String getTargetTypeId() { return targetTypeId; }
+
+   public void setTargetTypeId(final String targetTypeId) { this.targetTypeId = targetTypeId; }
+
+   public EditorContext getEditorContext() { return editorContext; }
+
+   public void setEditorContext(final EditorContext editorContext) { this.editorContext = editorContext; }
+
+}

--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/kind/ResolveNavigationTargetAction.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/kind/ResolveNavigationTargetAction.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ******************************************************************************/
+package org.eclipse.glsp.api.action.kind;
+
+import org.eclipse.glsp.api.action.Action;
+import org.eclipse.glsp.api.types.NavigationTarget;
+
+public class ResolveNavigationTargetAction extends RequestAction<SetResolvedNavigationTargetAction> {
+
+   private NavigationTarget navigationTarget;
+
+   public ResolveNavigationTargetAction() {
+      super(Action.Kind.RESOLVE_NAVIGATION_TARGET);
+   }
+
+   public ResolveNavigationTargetAction(final NavigationTarget target) {
+      this();
+      this.navigationTarget = target;
+   }
+
+   public NavigationTarget getNavigationTarget() { return navigationTarget; }
+
+   public void setNavigationTarget(final NavigationTarget navigationTarget) {
+      this.navigationTarget = navigationTarget;
+   }
+
+}

--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/kind/SetNavigationTargetsAction.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/kind/SetNavigationTargetsAction.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ******************************************************************************/
+package org.eclipse.glsp.api.action.kind;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.glsp.api.action.Action;
+import org.eclipse.glsp.api.types.NavigationTarget;
+
+public class SetNavigationTargetsAction extends ResponseAction {
+
+   private List<NavigationTarget> targets;
+   private Map<String, String> args;
+
+   public SetNavigationTargetsAction() {
+      super(Action.Kind.SET_NAVIGATION_TARGETS);
+   }
+
+   public SetNavigationTargetsAction(final List<NavigationTarget> targets, final Map<String, String> map) {
+      this();
+      this.targets = targets;
+      this.args = map;
+   }
+
+   public List<NavigationTarget> getTargets() { return targets; }
+
+   public void setTargets(final List<NavigationTarget> targets) { this.targets = targets; }
+
+   public Map<String, String> getArgs() { return args; }
+
+   public void setArgs(final Map<String, String> args) { this.args = args; }
+}

--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/kind/SetResolvedNavigationTargetAction.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/kind/SetResolvedNavigationTargetAction.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ******************************************************************************/
+package org.eclipse.glsp.api.action.kind;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.glsp.api.action.Action;
+
+public class SetResolvedNavigationTargetAction extends ResponseAction {
+
+   private List<String> elementIds;
+   private Map<String, String> args;
+
+   public SetResolvedNavigationTargetAction() {
+      super(Action.Kind.SET_RESOLVED_NAVIGATION_TARGET);
+   }
+
+   public SetResolvedNavigationTargetAction(final List<String> elementIds, final Map<String, String> map) {
+      this();
+      this.elementIds = elementIds;
+      this.args = map;
+   }
+
+   public List<String> getElementIds() { return elementIds; }
+
+   public void setElementIds(final List<String> elementIds) { this.elementIds = elementIds; }
+
+   public Map<String, String> getArgs() { return args; }
+
+   public void setArgs(final Map<String, String> args) { this.args = args; }
+}

--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/di/GLSPModule.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/di/GLSPModule.java
@@ -28,6 +28,7 @@ import org.eclipse.glsp.api.labeledit.LabelEditValidator;
 import org.eclipse.glsp.api.layout.ILayoutEngine;
 import org.eclipse.glsp.api.markers.ModelValidator;
 import org.eclipse.glsp.api.model.ModelStateProvider;
+import org.eclipse.glsp.api.model.NavigationTargetResolver;
 import org.eclipse.glsp.api.provider.CommandPaletteActionProvider;
 import org.eclipse.glsp.api.provider.ContextMenuItemProvider;
 import org.eclipse.glsp.api.provider.ToolPaletteItemProvider;
@@ -36,6 +37,7 @@ import org.eclipse.glsp.api.registry.ActionRegistry;
 import org.eclipse.glsp.api.registry.ContextActionsProviderRegistry;
 import org.eclipse.glsp.api.registry.ContextEditValidatorRegistry;
 import org.eclipse.glsp.api.registry.DiagramConfigurationRegistry;
+import org.eclipse.glsp.api.registry.NavigationTargetProviderRegistry;
 import org.eclipse.glsp.api.registry.OperationHandlerRegistry;
 import org.eclipse.glsp.api.registry.ServerCommandHandlerRegistry;
 import org.eclipse.glsp.graph.GraphExtension;
@@ -62,6 +64,7 @@ public abstract class GLSPModule extends AbstractModule {
       bind(ToolPaletteItemProvider.class).to(bindToolPaletteItemProvider());
       bind(CommandPaletteActionProvider.class).to(bindCommandPaletteActionProvider());
       bind(ContextMenuItemProvider.class).to(bindContextMenuItemProvider());
+      bind(NavigationTargetResolver.class).to(bindNavigationTargetResolver());
 
       // Configure set suppliers
       bind(ActionRegistry.class).to(bindActionRegistry()).in(Singleton.class);
@@ -69,6 +72,7 @@ public abstract class GLSPModule extends AbstractModule {
       bind(OperationHandlerRegistry.class).to(bindOperationHandlerRegistry()).in(Singleton.class);
       bind(DiagramConfigurationRegistry.class).to(bindDiagramConfigurationRegistry()).in(Singleton.class);
       bind(ContextActionsProviderRegistry.class).to(bindContextActionsProviderRegistry()).in(Singleton.class);
+      bind(NavigationTargetProviderRegistry.class).to(bindNavigationTargetProviderRegistry()).in(Singleton.class);
       bind(ContextEditValidatorRegistry.class).to(bindContextEditValidatorRegistry()).in(Singleton.class);
       bind(ServerCommandHandlerRegistry.class).to(bindServerCommandHandlerRegistry()).in(Singleton.class);
       // Configure Optional Bindings (Bindings that cannot be bound to a NullImpl)
@@ -123,6 +127,10 @@ public abstract class GLSPModule extends AbstractModule {
       return ToolPaletteItemProvider.NullImpl.class;
    }
 
+   protected Class<? extends NavigationTargetResolver> bindNavigationTargetResolver() {
+      return NavigationTargetResolver.NullImpl.class;
+   }
+
    protected abstract Class<? extends ActionRegistry> bindActionRegistry();
 
    protected abstract Class<? extends ActionHandlerRegistry> bindActionHandlerRegistry();
@@ -132,6 +140,8 @@ public abstract class GLSPModule extends AbstractModule {
    protected abstract Class<? extends DiagramConfigurationRegistry> bindDiagramConfigurationRegistry();
 
    protected abstract Class<? extends ContextActionsProviderRegistry> bindContextActionsProviderRegistry();
+
+   protected abstract Class<? extends NavigationTargetProviderRegistry> bindNavigationTargetProviderRegistry();
 
    protected abstract Class<? extends ContextEditValidatorRegistry> bindContextEditValidatorRegistry();
 

--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/model/NavigationTargetResolver.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/model/NavigationTargetResolver.java
@@ -1,0 +1,73 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.api.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.glsp.api.types.NavigationTarget;
+import org.eclipse.glsp.api.types.NavigationTargetResolution;
+
+public interface NavigationTargetResolver {
+
+   String INFO = "info";
+   String WARNING = "warning";
+   String ERROR = "error";
+
+   NavigationTargetResolution resolve(NavigationTarget navigationTarget, GraphicalModelState modelState);
+
+   default Map<String, String> createArgs() {
+      return new HashMap<>();
+   }
+
+   default Map<String, String> createArgsWithInfo(final String message) {
+      Map<String, String> args = createArgs();
+      addInfo(message, args);
+      return args;
+   }
+
+   default Map<String, String> createArgsWithWarning(final String message) {
+      Map<String, String> args = createArgs();
+      addWarning(message, args);
+      return args;
+   }
+
+   default Map<String, String> createArgsWithError(final String message) {
+      Map<String, String> args = createArgs();
+      addError(message, args);
+      return args;
+   }
+
+   default void addInfo(final String message, final Map<String, String> args) {
+      args.put(INFO, message);
+   }
+
+   default void addWarning(final String message, final Map<String, String> args) {
+      args.put(WARNING, message);
+   }
+
+   default void addError(final String message, final Map<String, String> args) {
+      args.put(ERROR, message);
+   }
+
+   public class NullImpl implements NavigationTargetResolver {
+      @Override
+      public NavigationTargetResolution resolve(final NavigationTarget navigationTarget,
+         final GraphicalModelState modelState) {
+         return NavigationTargetResolution.EMPTY;
+      }
+   }
+}

--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/provider/NavigationTargetProvider.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/provider/NavigationTargetProvider.java
@@ -1,0 +1,55 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.api.provider;
+
+import java.util.List;
+
+import org.eclipse.glsp.api.model.GraphicalModelState;
+import org.eclipse.glsp.api.types.EditorContext;
+import org.eclipse.glsp.api.types.NavigationTarget;
+
+public interface NavigationTargetProvider {
+
+   String JSON_OPENER_OPTIONS = "jsonOpenerOptions";
+
+   /**
+    * Specifies the navigation targets for the given target type.
+    * <p>
+    * If the <code>args</code> of a returned {@link NavigationTarget} contain a
+    * {@link NavigationTarget#ELEMENT_IDS}, GLSP diagram clients should navigate to
+    * the model elements with the specified ID within the current diagram. Multiple element
+    * IDs can be concatenated with {@link NavigationTarget#ELEMENT_IDS_SEPARATOR}.
+    * <p>
+    * If the <code>args</code> of a returned {@link NavigationTarget} contain a property
+    * {@link #JSON_OPENER_OPTIONS} and its uri is outside of the current diagram, the string
+    * value of the {@value #JSON_OPENER_OPTIONS} property will be parsed as JSON
+    * and merged into the opener options by the Theia integration of the GLSP client.
+    * This allows GLSP servers to pass additional opener options, such as a selection, etc.
+    * Other clients (non-Theia clients) should behave the same way.
+    *
+    * @param editorContext The editor context
+    * @param modelState    The model state
+    * @return the list of navigation targets
+    */
+   List<? extends NavigationTarget> getTargets(EditorContext editorContext, GraphicalModelState modelState);
+
+   String getTargetTypeId();
+
+   default boolean handles(final String targetTypeId) {
+      return getTargetTypeId().equals(targetTypeId);
+   }
+
+}

--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/registry/NavigationTargetProviderRegistry.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/registry/NavigationTargetProviderRegistry.java
@@ -1,0 +1,20 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.api.registry;
+
+import org.eclipse.glsp.api.provider.NavigationTargetProvider;
+
+public interface NavigationTargetProviderRegistry extends Registry<String, NavigationTargetProvider> {}

--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/types/NavigationTarget.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/types/NavigationTarget.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ******************************************************************************/
+package org.eclipse.glsp.api.types;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class NavigationTarget {
+
+   public static final String ELEMENT_IDS = "elementIds";
+   public static final String ELEMENT_IDS_SEPARATOR = "&";
+   public static final String TEXT_LINE = "line";
+   public static final String TEXT_COLUMN = "column";
+
+   private final String uri;
+   private final String label;
+   private Map<String, String> args;
+
+   public NavigationTarget(final String uri) {
+      this(uri, new HashMap<String, String>());
+   }
+
+   public NavigationTarget(final String uri, final String label) {
+      this(uri, label, new HashMap<String, String>());
+   }
+
+   public NavigationTarget(final String uri, final Map<String, String> args) {
+      this(uri, null, args);
+   }
+
+   public NavigationTarget(final String uri, final String label, final Map<String, String> args) {
+      super();
+      this.uri = uri;
+      this.label = label;
+      this.args = args;
+   }
+
+   public String getUri() { return uri; }
+
+   public String getLabel() { return label; }
+
+   public Map<String, String> getArgs() { return args; }
+
+   public List<String> getElementIds() {
+      if (this.args == null || this.args.get(ELEMENT_IDS) == null || this.args.get(ELEMENT_IDS).isEmpty()) {
+         return Arrays.asList();
+      }
+      return Arrays.asList(this.args.get(ELEMENT_IDS).split(ELEMENT_IDS_SEPARATOR));
+   }
+
+   public void setElementIds(final List<String> elementIds) {
+      if (this.args == null) {
+         this.args = new HashMap<>();
+      }
+      this.args.put(ELEMENT_IDS, elementIds.stream().collect(Collectors.joining(ELEMENT_IDS_SEPARATOR)));
+   }
+
+   public boolean hasTextPosition() {
+      boolean hasValues = this.args != null && this.args.containsKey(TEXT_LINE) && this.args.containsKey(TEXT_COLUMN);
+      if (!hasValues) {
+         return false;
+      }
+      try {
+         Integer.valueOf(this.args.get(TEXT_LINE));
+         Integer.valueOf(this.args.get(TEXT_COLUMN));
+         return true;
+      } catch (NumberFormatException nfe) {
+         return false;
+      }
+   }
+
+   public void setTextPosition(final int line, final int column) {
+      this.args.put(TEXT_LINE, String.valueOf(line));
+      this.args.put(TEXT_COLUMN, String.valueOf(column));
+   }
+
+   public int getTextPositionLine() { return Integer.valueOf(this.args.get(TEXT_LINE)); }
+
+   public int getTextPositionColumn() { return Integer.valueOf(this.args.get(TEXT_COLUMN)); }
+
+}

--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/types/NavigationTargetResolution.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/types/NavigationTargetResolution.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019 EclipseSource and others.
+ * Copyright (c) 2020 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,32 +17,35 @@ package org.eclipse.glsp.api.types;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
-import org.eclipse.glsp.graph.GPoint;
+public class NavigationTargetResolution {
 
-public class EditorContext {
+   public static final NavigationTargetResolution EMPTY = new NavigationTargetResolution();
 
-   private List<String> selectedElementIds;
-   private GPoint lastMousePosition;
-   private String sourceUri;
+   private List<String> elementIds;
    private Map<String, String> args;
 
-   public EditorContext() {}
-
-   public List<String> getSelectedElementIds() { return selectedElementIds; }
-
-   public void setSelectedElementIds(final List<String> selectedElementIds) {
-      this.selectedElementIds = selectedElementIds;
+   public NavigationTargetResolution() {
+      this(null, null);
    }
 
-   public Optional<GPoint> getLastMousePosition() { return Optional.ofNullable(lastMousePosition); }
+   public NavigationTargetResolution(final List<String> elementIds) {
+      this(elementIds, null);
+   }
 
-   public void setLastMousePosition(final GPoint lastMousePosition) { this.lastMousePosition = lastMousePosition; }
+   public NavigationTargetResolution(final Map<String, String> args) {
+      this(null, args);
+   }
 
-   public String getSourceUri() { return sourceUri; }
+   public NavigationTargetResolution(final List<String> elementIds, final Map<String, String> args) {
+      super();
+      this.elementIds = elementIds;
+      this.args = args;
+   }
 
-   public void setSourceUri(final String sourceUri) { this.sourceUri = sourceUri; }
+   public List<String> getElementIds() { return elementIds; }
+
+   public void setElementIds(final List<String> elementIds) { this.elementIds = elementIds; }
 
    public Map<String, String> getArgs() { return args; }
 

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actionhandler/RequestNavigationTargetsActionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actionhandler/RequestNavigationTargetsActionHandler.java
@@ -1,0 +1,46 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.server.actionhandler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.glsp.api.action.Action;
+import org.eclipse.glsp.api.action.kind.RequestNavigationTargetsAction;
+import org.eclipse.glsp.api.action.kind.SetNavigationTargetsAction;
+import org.eclipse.glsp.api.model.GraphicalModelState;
+import org.eclipse.glsp.api.registry.NavigationTargetProviderRegistry;
+import org.eclipse.glsp.api.types.EditorContext;
+import org.eclipse.glsp.api.types.NavigationTarget;
+
+import com.google.inject.Inject;
+
+public class RequestNavigationTargetsActionHandler extends BasicActionHandler<RequestNavigationTargetsAction> {
+
+   @Inject
+   protected NavigationTargetProviderRegistry navigationTargetProviderRegistry;
+
+   @Override
+   public List<Action> executeAction(final RequestNavigationTargetsAction action,
+      final GraphicalModelState modelState) {
+      EditorContext editorContext = action.getEditorContext();
+      List<NavigationTarget> allTargets = new ArrayList<>();
+      navigationTargetProviderRegistry.get(action.getTargetTypeId())
+         .map(provider -> provider.getTargets(editorContext, modelState))
+         .ifPresent(targets -> allTargets.addAll(targets));
+      return listOf(new SetNavigationTargetsAction(allTargets, action.getEditorContext().getArgs()));
+   }
+}

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actionhandler/ResolveNavigationTargetActionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actionhandler/ResolveNavigationTargetActionHandler.java
@@ -1,0 +1,41 @@
+/********************************************************************************
+ * Copyright (c) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.server.actionhandler;
+
+import java.util.List;
+
+import org.eclipse.glsp.api.action.Action;
+import org.eclipse.glsp.api.action.kind.ResolveNavigationTargetAction;
+import org.eclipse.glsp.api.action.kind.SetResolvedNavigationTargetAction;
+import org.eclipse.glsp.api.model.GraphicalModelState;
+import org.eclipse.glsp.api.model.NavigationTargetResolver;
+import org.eclipse.glsp.api.types.NavigationTarget;
+import org.eclipse.glsp.api.types.NavigationTargetResolution;
+
+import com.google.inject.Inject;
+
+public class ResolveNavigationTargetActionHandler extends BasicActionHandler<ResolveNavigationTargetAction> {
+
+   @Inject
+   protected NavigationTargetResolver navigationTargetResolver;
+
+   @Override
+   public List<Action> executeAction(final ResolveNavigationTargetAction action, final GraphicalModelState modelState) {
+      NavigationTarget target = action.getNavigationTarget();
+      NavigationTargetResolution resolution = this.navigationTargetResolver.resolve(target, modelState);
+      return listOf(new SetResolvedNavigationTargetAction(resolution.getElementIds(), resolution.getArgs()));
+   }
+}

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/DefaultGLSPModule.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/DefaultGLSPModule.java
@@ -31,12 +31,14 @@ import org.eclipse.glsp.api.jsonrpc.GLSPServer;
 import org.eclipse.glsp.api.model.ModelStateProvider;
 import org.eclipse.glsp.api.provider.ContextActionsProvider;
 import org.eclipse.glsp.api.provider.ContextEditValidator;
+import org.eclipse.glsp.api.provider.NavigationTargetProvider;
 import org.eclipse.glsp.api.provider.ToolPaletteItemProvider;
 import org.eclipse.glsp.api.registry.ActionHandlerRegistry;
 import org.eclipse.glsp.api.registry.ActionRegistry;
 import org.eclipse.glsp.api.registry.ContextActionsProviderRegistry;
 import org.eclipse.glsp.api.registry.ContextEditValidatorRegistry;
 import org.eclipse.glsp.api.registry.DiagramConfigurationRegistry;
+import org.eclipse.glsp.api.registry.NavigationTargetProviderRegistry;
 import org.eclipse.glsp.api.registry.OperationHandlerRegistry;
 import org.eclipse.glsp.api.registry.ServerCommandHandlerRegistry;
 import org.eclipse.glsp.server.action.DefaultActionProcessor;
@@ -51,6 +53,7 @@ import org.eclipse.glsp.server.registry.DIActionRegistry;
 import org.eclipse.glsp.server.registry.DIContextActionsProviderRegistry;
 import org.eclipse.glsp.server.registry.DIContextEditValidatorRegistry;
 import org.eclipse.glsp.server.registry.DIDiagramConfigurationRegistry;
+import org.eclipse.glsp.server.registry.DINavigationTargetProviderRegistry;
 import org.eclipse.glsp.server.registry.DIOperationHandlerRegistry;
 import org.eclipse.glsp.server.registry.DIServerCommandHandlerRegistry;
 
@@ -59,7 +62,6 @@ public abstract class DefaultGLSPModule extends GLSPModule {
    @Override
    public void configure() {
       super.configure();
-      // Configure MultiBindings
       configureMultiBindConfigs();
    }
 
@@ -71,6 +73,7 @@ public abstract class DefaultGLSPModule extends GLSPModule {
       configure(MultiBindConfig.create(DiagramConfiguration.class), this::configureDiagramConfigurations);
       configure(MultiBindConfig.create(ContextActionsProvider.class), this::configureContextActionsProviders);
       configure(MultiBindConfig.create(ContextEditValidator.class), this::configureContextEditValidators);
+      configure(MultiBindConfig.create(NavigationTargetProvider.class), this::configureNavigationTargetProviders);
    }
 
    protected <T> void configure(final MultiBindConfig<T> multiBindings,
@@ -99,6 +102,8 @@ public abstract class DefaultGLSPModule extends GLSPModule {
    protected void configureContextActionsProviders(final MultiBindConfig<ContextActionsProvider> config) {}
 
    protected void configureContextEditValidators(final MultiBindConfig<ContextEditValidator> config) {}
+
+   protected void configureNavigationTargetProviders(final MultiBindConfig<NavigationTargetProvider> config) {}
 
    @Override
    protected Class<? extends GLSPServer> bindGLSPServer() {
@@ -158,6 +163,11 @@ public abstract class DefaultGLSPModule extends GLSPModule {
    @Override
    protected Class<? extends ContextActionsProviderRegistry> bindContextActionsProviderRegistry() {
       return DIContextActionsProviderRegistry.class;
+   }
+
+   @Override
+   protected Class<? extends NavigationTargetProviderRegistry> bindNavigationTargetProviderRegistry() {
+      return DINavigationTargetProviderRegistry.class;
    }
 
    @Override

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/MultiBindingDefaults.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/MultiBindingDefaults.java
@@ -46,8 +46,10 @@ import org.eclipse.glsp.server.actionhandler.RequestContextActionsHandler;
 import org.eclipse.glsp.server.actionhandler.RequestEditValidationHandler;
 import org.eclipse.glsp.server.actionhandler.RequestMarkersHandler;
 import org.eclipse.glsp.server.actionhandler.RequestModelActionHandler;
+import org.eclipse.glsp.server.actionhandler.RequestNavigationTargetsActionHandler;
 import org.eclipse.glsp.server.actionhandler.RequestPopupModelActionHandler;
 import org.eclipse.glsp.server.actionhandler.RequestTypeHintsActionHandler;
+import org.eclipse.glsp.server.actionhandler.ResolveNavigationTargetActionHandler;
 import org.eclipse.glsp.server.actionhandler.SaveModelActionHandler;
 import org.eclipse.glsp.server.actionhandler.UndoRedoActionHandler;
 import org.eclipse.glsp.server.operationhandler.ApplyLabelEditOperationHandler;
@@ -92,7 +94,9 @@ public final class MultiBindingDefaults {
       SaveModelActionHandler.class,
       UndoRedoActionHandler.class,
       ExecuteServerCommandActionHandler.class,
+      ResolveNavigationTargetActionHandler.class,
       RequestClipboardDataActionHandler.class,
+      RequestNavigationTargetsActionHandler.class,
       RequestTypeHintsActionHandler.class,
       RequestContextActionsHandler.class,
       RequestEditValidationHandler.class,

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/registry/DINavigationTargetProviderRegistry.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/registry/DINavigationTargetProviderRegistry.java
@@ -1,0 +1,33 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.server.registry;
+
+import java.util.Set;
+
+import org.eclipse.glsp.api.provider.NavigationTargetProvider;
+import org.eclipse.glsp.api.registry.MapRegistry;
+import org.eclipse.glsp.api.registry.NavigationTargetProviderRegistry;
+
+import com.google.inject.Inject;
+
+public class DINavigationTargetProviderRegistry extends MapRegistry<String, NavigationTargetProvider>
+   implements NavigationTargetProviderRegistry {
+
+   @Inject
+   public DINavigationTargetProviderRegistry(final Set<NavigationTargetProvider> navigationTargetProviders) {
+      navigationTargetProviders.forEach(provider -> register(provider.getTargetTypeId(), provider));
+   }
+}


### PR DESCRIPTION
This change adds the mechanism for allowing to register `NavigationTargetProvider` to define domain-specific navigations (such as definition, implementation, ...) to diagram-internal elements or diagram-external resources, as well as a `NavigationTargetResolver` for looking up element IDs based on any arguments (e.g. queries).

https://github.com/eclipse-glsp/glsp/issues/69