### PR TITLE
#75 Update to LSP4J 0.9.0

### DIFF
--- a/plugins/org.eclipse.glsp.api/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.api/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Vendor: EclipseSource
 Automatic-Module-Name: org.eclipse.glsp.api
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.lsp4j,
- org.eclipse.lsp4j.jsonrpc;bundle-version="0.6.0",
+ org.eclipse.lsp4j.jsonrpc;bundle-version="0.8.0",
  javax.websocket;bundle-version="1.0.0";visibility:=reexport,
  org.eclipse.glsp.graph;bundle-version="0.7.0";visibility:=reexport,
  com.google.gson,

--- a/plugins/org.eclipse.glsp.api/pom.xml
+++ b/plugins/org.eclipse.glsp.api/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.lsp4j</groupId>
 			<artifactId>org.eclipse.lsp4j.jsonrpc</artifactId>
-			<version>0.8.1</version>
+			<version>0.9.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.inject</groupId>

--- a/plugins/org.eclipse.glsp.server.websocket/pom.xml
+++ b/plugins/org.eclipse.glsp.server.websocket/pom.xml
@@ -67,7 +67,7 @@
 		<dependency>
 			<groupId>org.eclipse.lsp4j</groupId>
 			<artifactId>org.eclipse.lsp4j.websocket</artifactId>
-			<version>0.8.1</version>
+			<version>0.9.0</version>
 		</dependency>
 	</dependencies>
 

--- a/plugins/org.eclipse.glsp.server/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.server/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Require-Bundle: org.eclipse.glsp.api;bundle-version="0.7.0";visibility:=reexport
  org.apache.commons.io;bundle-version="2.2.0",
  org.eclipse.emf.ecore.change;bundle-version="2.13.0",
  com.google.gson;bundle-version="2.8.2",
- org.eclipse.lsp4j,
+ org.eclipse.lsp4j;bundle-version="0.8.0",
  org.eclipse.lsp4j.jsonrpc,
  com.google.guava;bundle-version="21.0.0"
 Import-Package: com.google.inject.multibindings;version="1.3.0"

--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
 								<artifact>
 									<groupId>org.eclipse.glsp</groupId>
 									<artifactId>org.eclipse.glsp.parent</artifactId>
-									<classifier>targetplatforms/r2019-12</classifier>
+									<classifier>targetplatforms/r2020-06</classifier>
 									<version>${target.version}</version>
 								</artifact>
 							</target>

--- a/targetplatforms/r2020-06.target
+++ b/targetplatforms/r2020-06.target
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="2019-12 - Release" sequenceNumber="1584016407">
+<target name="2020-06 - Release" sequenceNumber="1593006377">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.2.400.v20191014-1907"/>
-      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.600.v20191014-2025"/>
-      <unit id="org.eclipse.emf.sdk.feature.group" version="2.20.0.v20191028-0905"/>
-      <repository location="http://download.eclipse.org/releases/2019-12"/>
+      <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.2.600.v20200521-1852"/>
+      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.800.v20200514-1529"/>
+      <unit id="org.eclipse.emf.sdk.feature.group" version="2.22.0.v20200519-1135"/>
+      <repository location="http://download.eclipse.org/releases/2020-06"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.apache.log4j" version="1.2.15.v201012070815"/>
@@ -18,8 +18,8 @@
       <unit id="com.google.inject.multibindings" version="3.0.0.v201605172100"/>
       <unit id="com.google.guava" version="27.1.0.v20190517-1946"/>
       <unit id="org.junit" version="4.12.0.v201504281640"/>
-      <unit id="org.junit.jupiter.api" version="5.5.1.v20190826-0900"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20191126223242/repository/"/>
+      <unit id="org.junit.jupiter.api" version="5.6.0.v20200203-2009"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.jetty.bundles.f.feature.group" version="9.4.14.v20181113"/>
@@ -36,7 +36,7 @@
       <unit id="org.eclipse.lsp4j" version="0.0.0"/>
       <unit id="org.eclipse.lsp4j.jsonrpc" version="0.0.0"/>
       <unit id="org.eclipse.lsp4j.websocket" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.8.1/"/>
+      <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.9.0"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.apache.jasper" version="8.5.35"/>

--- a/targetplatforms/r2020-06.tpd
+++ b/targetplatforms/r2020-06.tpd
@@ -1,12 +1,12 @@
-target "2019-12 - Release" with source requirements
+target "2020-06 - Release" with source requirements
 
-location "http://download.eclipse.org/releases/2019-12" {
+location "http://download.eclipse.org/releases/2020-06" {
 	org.eclipse.equinox.p2.discovery.feature.feature.group
 	org.eclipse.equinox.executable.feature.group
 	org.eclipse.emf.sdk.feature.group
 }
 
-location "https://download.eclipse.org/tools/orbit/downloads/drops/R20191126223242/repository/" {
+location "https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository/" {
 	org.apache.log4j
 	org.apache.commons.io
 	javax.servlet
@@ -15,7 +15,7 @@ location "https://download.eclipse.org/tools/orbit/downloads/drops/R201911262232
 	com.google.inject.multibindings [3.0.0,3.0.1)
 	com.google.guava [27.1.0,27.1.1)
 	org.junit [4.12.0,4.13.0)
-	org.junit.jupiter.api [5.5.1,5.6.0)
+	org.junit.jupiter.api [5.6.0,5.6.1)
 }
 
 location "https://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.14.v20181113/" {
@@ -29,7 +29,7 @@ location "https://download.eclipse.org/elk/updates/releases/0.6.0/" {
 	org.eclipse.elk.alg.layered
 }
 
-location "https://download.eclipse.org/lsp4j/updates/releases/0.8.1/" {
+location "https://download.eclipse.org/lsp4j/updates/releases/0.9.0" {
 	org.eclipse.lsp4j lazy
 	org.eclipse.lsp4j.jsonrpc lazy
 	org.eclipse.lsp4j.websocket lazy


### PR DESCRIPTION
Update to LSP4J 0.9.0 and also update targetplatform to 2020-06 release.
Resolves https://github.com/eclipse-glsp/glsp/issues/75