### PR TITLE
#42 Add customizable location retrieval to CreateNodeOperationHandler

### DIFF
--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operationhandler/CreateNodeOperationHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operationhandler/CreateNodeOperationHandler.java
@@ -39,8 +39,12 @@ public abstract class CreateNodeOperationHandler extends BasicCreateOperationHan
          container = Optional.of(modelState.getRoot());
       }
 
-      GModelElement element = createNode(operation.getLocation(), modelState);
+      GModelElement element = createNode(getLocation(operation), modelState);
       container.get().getChildren().add(element);
+   }
+
+   protected Optional<GPoint> getLocation(final CreateNodeOperation operation) {
+      return operation.getLocation();
    }
 
    protected abstract GNode createNode(Optional<GPoint> point, GraphicalModelState modelState);


### PR DESCRIPTION
The default implementation just returns the location provided by the operation. Subclasses can overwrite this behavior. (e.g. for grind snapping).
Part of eclipse-glsp/glsp/issues/42