### PR TITLE
#87 Add readonly support for GLSP diagrams

### DIFF
--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/Action.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/Action.java
@@ -81,5 +81,6 @@ public abstract class Action {
       public static final String VALIDATE_LABEL_EDIT_ACTION = "validateLabelEdit";
       public static final String RESOLVE_NAVIGATION_TARGET = "resolveNavigationTarget";
       public static final String SET_RESOLVED_NAVIGATION_TARGET = "setResolvedNavigationTarget";
+      public static final String SET_EDIT_MODE = "setEditMode";
    }
 }

--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/kind/SetEditModeAction.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/kind/SetEditModeAction.java
@@ -1,0 +1,38 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.api.action.kind;
+
+import org.eclipse.glsp.api.action.Action;
+
+public class SetEditModeAction extends Action {
+   public static final String EDIT_MODE_READONLY = "readonly";
+   public static final String EDIT_MODE_EDITABLE = "editable";
+   private String editMode;
+
+   public SetEditModeAction() {
+      super(Action.Kind.SET_EDIT_MODE);
+   }
+
+   public SetEditModeAction(final String editMode) {
+      this();
+      this.editMode = editMode;
+   }
+
+   public String getEditMode() { return editMode; }
+
+   public void setEditMode(final String editMode) { this.editMode = editMode; }
+
+}

--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/di/GLSPModule.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/di/GLSPModule.java
@@ -87,9 +87,7 @@ public abstract class GLSPModule extends AbstractModule {
 
    protected abstract Class<? extends GraphGsonConfiguratorFactory> bindGraphGsonConfiguratorFactory();
 
-   protected Class<? extends ModelFactory> bindModelFactory() {
-      return ModelFactory.NullImpl.class;
-   }
+   protected abstract Class<? extends ModelFactory> bindModelFactory();
 
    protected Class<? extends PopupModelFactory> bindPopupModelFactory() {
       return PopupModelFactory.NullImpl.class;

--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/model/GraphicalModelState.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/model/GraphicalModelState.java
@@ -15,24 +15,15 @@
  ******************************************************************************/
 package org.eclipse.glsp.api.model;
 
-import java.util.Map;
-import java.util.Set;
-
+import org.eclipse.emf.common.command.Command;
 import org.eclipse.glsp.graph.GModelIndex;
 import org.eclipse.glsp.graph.GModelRoot;
 
 public interface GraphicalModelState extends ModelState<GModelRoot> {
-   Map<String, String> getClientOptions();
-
-   void setClientOptions(Map<String, String> options);
-
-   Set<String> getExpandedElements();
-
-   Set<String> getSelectedElements();
-
-   void setExpandedElements(Set<String> expandedElements);
-
-   void setSelectedElements(Set<String> selectedElements);
 
    GModelIndex getIndex();
+
+   void saveIsDone();
+
+   void execute(Command command);
 }

--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/model/ModelState.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/model/ModelState.java
@@ -15,7 +15,7 @@
  ******************************************************************************/
 package org.eclipse.glsp.api.model;
 
-import org.eclipse.emf.common.command.Command;
+import java.util.Map;
 
 public interface ModelState<T> {
 
@@ -23,11 +23,13 @@ public interface ModelState<T> {
 
    void setClientId(String clientId);
 
+   Map<String, String> getClientOptions();
+
+   void setClientOptions(Map<String, String> options);
+
    T getRoot();
 
    void setRoot(T newRoot);
-
-   void execute(Command command);
 
    boolean canUndo();
 
@@ -39,6 +41,7 @@ public interface ModelState<T> {
 
    boolean isDirty();
 
-   void saveIsDone();
+   boolean isReadonly();
 
+   void setReadonly(boolean readonly);
 }

--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/utils/ClientOptions.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/utils/ClientOptions.java
@@ -26,12 +26,12 @@ public final class ClientOptions {
    private ClientOptions() {}
 
    public static Optional<String> getValue(final Map<String, String> options, final String key) {
-      return Optional.ofNullable(options.get(key));
+      return Optional.ofNullable(options).map(opt -> opt.get(key));
    }
 
    public static Optional<Integer> getIntValue(final Map<String, String> options, final String key) {
       try {
-         return Optional.ofNullable(Integer.parseInt(options.get(key)));
+         return Optional.ofNullable(options).map(opt -> Integer.parseInt(opt.get(key)));
       } catch (NumberFormatException ex) {
          return Optional.empty();
       }
@@ -39,13 +39,13 @@ public final class ClientOptions {
 
    public static Optional<Float> getFloatValue(final Map<String, String> options, final String key) {
       try {
-         return Optional.ofNullable(Float.parseFloat(options.get(key)));
+         return Optional.ofNullable(options).map(opt -> Float.parseFloat(opt.get(key)));
       } catch (NumberFormatException ex) {
          return Optional.empty();
       }
    }
 
    public static boolean getBoolValue(final Map<String, String> options, final String key) {
-      return Boolean.parseBoolean(options.get(key));
+      return Optional.ofNullable(options).map(opt -> Boolean.parseBoolean(opt.get(key))).orElse(false);
    }
 }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actionhandler/OperationActionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actionhandler/OperationActionHandler.java
@@ -27,6 +27,7 @@ import org.eclipse.glsp.api.model.GraphicalModelState;
 import org.eclipse.glsp.api.operation.CreateOperation;
 import org.eclipse.glsp.api.operation.Operation;
 import org.eclipse.glsp.api.registry.OperationHandlerRegistry;
+import org.eclipse.glsp.api.utils.ServerMessageUtil;
 import org.eclipse.glsp.server.command.GModelRecordingCommand;
 
 import com.google.inject.Inject;
@@ -42,12 +43,15 @@ public class OperationActionHandler extends BasicActionHandler<Operation> {
 
    @Override
    public List<Action> executeAction(final Operation operation, final GraphicalModelState modelState) {
+      if (modelState.isReadonly()) {
+         return listOf(ServerMessageUtil
+            .warn("Server is in readony-mode! Could not execute operation: " + operation.getKind()));
+      }
       Optional<? extends OperationHandler> operationHandler = getOperationHandler(operation, operationHandlerRegistry);
       if (operationHandler.isPresent()) {
          return executeHandler(operation, operationHandler.get(), modelState);
       }
       return none();
-
    }
 
    protected List<Action> executeHandler(final Operation operation, final OperationHandler handler,

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actionhandler/RequestModelActionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actionhandler/RequestModelActionHandler.java
@@ -39,7 +39,6 @@ public class RequestModelActionHandler extends BasicActionHandler<RequestModelAc
       GModelRoot model = modelFactory.loadModel(action, modelState);
       modelState.setRoot(model);
       modelState.setClientOptions(action.getOptions());
-
       boolean needsClientLayout = ClientOptions.getBoolValue(action.getOptions(),
          ClientOptions.NEEDS_CLIENT_LAYOUT);
 

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actionhandler/SetEditModeActionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actionhandler/SetEditModeActionHandler.java
@@ -1,0 +1,32 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.server.actionhandler;
+
+import java.util.List;
+
+import org.eclipse.glsp.api.action.Action;
+import org.eclipse.glsp.api.action.kind.SetEditModeAction;
+import org.eclipse.glsp.api.model.GraphicalModelState;
+
+public class SetEditModeActionHandler extends BasicActionHandler<SetEditModeAction> {
+
+   @Override
+   protected List<Action> executeAction(final SetEditModeAction action, final GraphicalModelState modelState) {
+      modelState.setReadonly(action.getEditMode().equals(SetEditModeAction.EDIT_MODE_READONLY));
+      return none();
+   }
+
+}

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/DefaultGLSPModule.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/DefaultGLSPModule.java
@@ -22,7 +22,6 @@ import org.eclipse.glsp.api.action.ActionProcessor;
 import org.eclipse.glsp.api.di.GLSPModule;
 import org.eclipse.glsp.api.diagram.DiagramConfiguration;
 import org.eclipse.glsp.api.factory.GraphGsonConfiguratorFactory;
-import org.eclipse.glsp.api.factory.ModelFactory;
 import org.eclipse.glsp.api.handler.ActionHandler;
 import org.eclipse.glsp.api.handler.OperationHandler;
 import org.eclipse.glsp.api.handler.ServerCommandHandler;
@@ -46,7 +45,6 @@ import org.eclipse.glsp.server.factory.DefaultGraphGsonConfiguratorFactory;
 import org.eclipse.glsp.server.jsonrpc.DefaultGLSPClientProvider;
 import org.eclipse.glsp.server.jsonrpc.DefaultGLSPServer;
 import org.eclipse.glsp.server.model.DefaultModelStateProvider;
-import org.eclipse.glsp.server.model.FileBasedModelFactory;
 import org.eclipse.glsp.server.provider.DefaultToolPaletteItemProvider;
 import org.eclipse.glsp.server.registry.DIActionHandlerRegistry;
 import org.eclipse.glsp.server.registry.DIActionRegistry;
@@ -113,11 +111,6 @@ public abstract class DefaultGLSPModule extends GLSPModule {
    @Override
    protected Class<? extends GraphGsonConfiguratorFactory> bindGraphGsonConfiguratorFactory() {
       return DefaultGraphGsonConfiguratorFactory.class;
-   }
-
-   @Override
-   protected Class<? extends ModelFactory> bindModelFactory() {
-      return FileBasedModelFactory.class;
    }
 
    @Override

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/MultiBindingDefaults.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/MultiBindingDefaults.java
@@ -51,6 +51,7 @@ import org.eclipse.glsp.server.actionhandler.RequestPopupModelActionHandler;
 import org.eclipse.glsp.server.actionhandler.RequestTypeHintsActionHandler;
 import org.eclipse.glsp.server.actionhandler.ResolveNavigationTargetActionHandler;
 import org.eclipse.glsp.server.actionhandler.SaveModelActionHandler;
+import org.eclipse.glsp.server.actionhandler.SetEditModeActionHandler;
 import org.eclipse.glsp.server.actionhandler.UndoRedoActionHandler;
 import org.eclipse.glsp.server.operationhandler.ApplyLabelEditOperationHandler;
 import org.eclipse.glsp.server.operationhandler.ChangeBoundsOperationHandler;
@@ -101,7 +102,8 @@ public final class MultiBindingDefaults {
       RequestTypeHintsActionHandler.class,
       RequestContextActionsHandler.class,
       RequestEditValidationHandler.class,
-      RequestMarkersHandler.class);
+      RequestMarkersHandler.class,
+      SetEditModeActionHandler.class);
 
    public static final List<Class<? extends OperationHandler>> DEFAULT_OPERATION_HANDLERS = Lists.newArrayList(
       ApplyLabelEditOperationHandler.class,

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/model/JsonFileModelFactory.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/model/JsonFileModelFactory.java
@@ -22,10 +22,10 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 
-import org.apache.log4j.Logger;
 import org.eclipse.glsp.api.action.kind.RequestModelAction;
 import org.eclipse.glsp.api.factory.GraphGsonConfiguratorFactory;
 import org.eclipse.glsp.api.factory.ModelFactory;
+import org.eclipse.glsp.api.jsonrpc.GLSPServerException;
 import org.eclipse.glsp.api.model.GraphicalModelState;
 import org.eclipse.glsp.api.utils.ClientOptions;
 import org.eclipse.glsp.graph.GGraph;
@@ -36,12 +36,10 @@ import com.google.inject.Inject;
 
 /**
  * A base class which can be used for all model factories that load an SModel
- * from a file (typically a json file).
+ * from a json file.
  *
- * @author Tobias Ortmayr
  */
-public class FileBasedModelFactory implements ModelFactory {
-   private static Logger LOGGER = Logger.getLogger(FileBasedModelFactory.class);
+public class JsonFileModelFactory implements ModelFactory {
    private static final String FILE_PREFIX = "file://";
 
    @Inject
@@ -57,7 +55,7 @@ public class FileBasedModelFactory implements ModelFactory {
             Gson gson = gsonConfigurationFactory.configureGson().create();
             modelRoot = gson.fromJson(reader, GGraph.class);
          } catch (IOException e) {
-            LOGGER.error(e);
+            throw new GLSPServerException("Could not load model from file: " + sourceURI, e);
          }
       }
       return modelRoot;

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/model/ModelStateImpl.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/model/ModelStateImpl.java
@@ -15,9 +15,7 @@
  ********************************************************************************/
 package org.eclipse.glsp.server.model;
 
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import org.eclipse.emf.common.command.BasicCommandStack;
 import org.eclipse.emf.common.command.Command;
@@ -33,13 +31,7 @@ public class ModelStateImpl implements GraphicalModelState {
    private String clientId;
    private GModelRoot currentModel;
    private BasicCommandStack commandStack;
-   private Set<String> expandedElements;
-   private Set<String> selectedElements;
-
-   public ModelStateImpl() {
-      expandedElements = new HashSet<>();
-      selectedElements = new HashSet<>();
-   }
+   private boolean readonly;
 
    @Override
    public Map<String, String> getClientOptions() { return options; }
@@ -77,22 +69,7 @@ public class ModelStateImpl implements GraphicalModelState {
    }
 
    @Override
-   public Set<String> getExpandedElements() { return expandedElements; }
-
-   @Override
-   public Set<String> getSelectedElements() { return selectedElements; }
-
-   @Override
    public void setClientOptions(final Map<String, String> options) { this.options = options; }
-
-   @Override
-   public void setExpandedElements(final Set<String> expandedElements) {
-      this.expandedElements = expandedElements;
-
-   }
-
-   @Override
-   public void setSelectedElements(final Set<String> selectedElements) { this.selectedElements = selectedElements; }
 
    @Override
    public GModelIndex getIndex() { return GModelIndex.get(currentModel); }
@@ -145,4 +122,9 @@ public class ModelStateImpl implements GraphicalModelState {
       commandStack.saveIsDone();
    }
 
+   @Override
+   public boolean isReadonly() { return readonly; }
+
+   @Override
+   public void setReadonly(final boolean readonly) { this.readonly = readonly; }
 }


### PR DESCRIPTION
- Add Readonly support to ModelState and disable operation execution when in readonly mode.
- Introduce SetEditMode action
- Refactor ModelState/GraphicalModelState
- Rename FilebaseModelfactory to JsonFileModelFactory and remove default binding
- Improve parsing methods for ClientOptions (proper handling of null args)
part of eclipse-glsp/glsp/issues/87