### PR TITLE
#87 Make editMode retrievable via ModelState

### DIFF
--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/model/ModelState.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/model/ModelState.java
@@ -17,6 +17,8 @@ package org.eclipse.glsp.api.model;
 
 import java.util.Map;
 
+import org.eclipse.glsp.api.action.kind.SetEditModeAction;
+
 public interface ModelState<T> {
 
    String getClientId();
@@ -41,7 +43,9 @@ public interface ModelState<T> {
 
    boolean isDirty();
 
-   boolean isReadonly();
+   String getEditMode();
 
-   void setReadonly(boolean readonly);
+   void setEditMode(String editMode);
+
+   default boolean isReadonly() { return getEditMode().equals(SetEditModeAction.EDIT_MODE_READONLY); }
 }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actionhandler/SetEditModeActionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actionhandler/SetEditModeActionHandler.java
@@ -25,7 +25,7 @@ public class SetEditModeActionHandler extends BasicActionHandler<SetEditModeActi
 
    @Override
    protected List<Action> executeAction(final SetEditModeAction action, final GraphicalModelState modelState) {
-      modelState.setReadonly(action.getEditMode().equals(SetEditModeAction.EDIT_MODE_READONLY));
+      modelState.setEditMode(action.getEditMode());
       return none();
    }
 

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/model/ModelStateImpl.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/model/ModelStateImpl.java
@@ -31,7 +31,7 @@ public class ModelStateImpl implements GraphicalModelState {
    private String clientId;
    private GModelRoot currentModel;
    private BasicCommandStack commandStack;
-   private boolean readonly;
+   private String editMode;
 
    @Override
    public Map<String, String> getClientOptions() { return options; }
@@ -123,8 +123,8 @@ public class ModelStateImpl implements GraphicalModelState {
    }
 
    @Override
-   public boolean isReadonly() { return readonly; }
+   public String getEditMode() { return this.editMode; }
 
    @Override
-   public void setReadonly(final boolean readonly) { this.readonly = readonly; }
+   public void setEditMode(final String editMode) { this.editMode = editMode; }
 }


### PR DESCRIPTION
Store `editMode` string literal in `ModelState` instead of just the readonly boolean flag.
Part of eclipse-glsp/glsp/issues/87