### PR TITLE
#21 Refactor ActionProcessor

### DIFF
--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/ActionDispatcher.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/ActionDispatcher.java
@@ -17,15 +17,15 @@ package org.eclipse.glsp.api.action;
 
 import java.util.List;
 
-public interface ActionProcessor {
+public interface ActionDispatcher {
 
    /**
-    * @see ActionProcessor#process(String, Action)
+    * @see ActionDispatcher#dispatch(String, Action)
     *
     * @param message ActionMessage received from the client
     */
-   default void process(final ActionMessage message) {
-      process(message.getClientId(), message.getAction());
+   default void dispatch(final ActionMessage message) {
+      dispatch(message.getClientId(), message.getAction());
    }
 
    /**
@@ -36,37 +36,24 @@ public interface ActionProcessor {
     * @param clientId The client from which the action was received
     * @param action   The action to dispatch
     */
-   void process(String clientId, Action action);
+   void dispatch(String clientId, Action action);
 
    /**
     * <p>
-    * Processes all given actions, received from the specified clientId, to the corresponding handlers.
+    * Processes all given actions, received from the specified clientId, by dispatching to the corresponding handlers.
     * </p>
     *
     * @param clientId
     * @param actions
     */
-   default void processAll(final String clientId, final List<Action> actions) {
-      actions.forEach(action -> process(clientId, action));
+   default void dispatchAll(final String clientId, final List<Action> actions) {
+      actions.forEach(action -> dispatch(clientId, action));
    }
 
-   /**
-    * Send the given action to the specified clientId.
-    *
-    * @param clientId The client to which the action should be sent
-    * @param action   The action to send to the client
-    */
-   void send(String clientId, Action action);
-
-   class NullImpl implements ActionProcessor {
+   class NullImpl implements ActionDispatcher {
 
       @Override
-      public void process(final String clientId, final Action action) {
-         return;
-      }
-
-      @Override
-      public void send(final String clientId, final Action action) {
+      public void dispatch(final String clientId, final Action action) {
          return;
       }
    }

--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/di/GLSPModule.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/di/GLSPModule.java
@@ -17,7 +17,7 @@ package org.eclipse.glsp.api.di;
 
 import java.util.Optional;
 
-import org.eclipse.glsp.api.action.ActionProcessor;
+import org.eclipse.glsp.api.action.ActionDispatcher;
 import org.eclipse.glsp.api.configuration.ServerConfiguration;
 import org.eclipse.glsp.api.factory.GraphGsonConfiguratorFactory;
 import org.eclipse.glsp.api.factory.ModelFactory;
@@ -55,7 +55,7 @@ public abstract class GLSPModule extends AbstractModule {
       bind(ModelFactory.class).to(bindModelFactory());
       bind(ILayoutEngine.class).to(bindLayoutEngine());
       bind(ModelValidator.class).to(bindModelValidator());
-      bind(ActionProcessor.class).to(bindActionProcessor()).in(Singleton.class);
+      bind(ActionDispatcher.class).to(bindActionDispatcher()).in(Singleton.class);
       bind(LabelEditValidator.class).to(bindLabelEditValidator());
       bind(ModelStateProvider.class).to(bindModelStateProvider());
       bind(GraphGsonConfiguratorFactory.class).to(bindGraphGsonConfiguratorFactory());
@@ -101,8 +101,8 @@ public abstract class GLSPModule extends AbstractModule {
       return ModelValidator.NullImpl.class;
    }
 
-   protected Class<? extends ActionProcessor> bindActionProcessor() {
-      return ActionProcessor.NullImpl.class;
+   protected Class<? extends ActionDispatcher> bindActionDispatcher() {
+      return ActionDispatcher.NullImpl.class;
    }
 
    protected Class<? extends LabelEditValidator> bindLabelEditValidator() {

--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/model/ModelState.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/model/ModelState.java
@@ -47,5 +47,5 @@ public interface ModelState<T> {
 
    void setEditMode(String editMode);
 
-   default boolean isReadonly() { return getEditMode().equals(SetEditModeAction.EDIT_MODE_READONLY); }
+   default boolean isReadonly() { return SetEditModeAction.EDIT_MODE_READONLY.equals(getEditMode()); }
 }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/DefaultGLSPModule.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/DefaultGLSPModule.java
@@ -20,7 +20,7 @@ import static org.eclipse.glsp.server.actionhandler.ClientActionHandler.CLIENT_A
 import java.util.function.Consumer;
 
 import org.eclipse.glsp.api.action.Action;
-import org.eclipse.glsp.api.action.ActionProcessor;
+import org.eclipse.glsp.api.action.ActionDispatcher;
 import org.eclipse.glsp.api.di.GLSPModule;
 import org.eclipse.glsp.api.diagram.DiagramConfiguration;
 import org.eclipse.glsp.api.factory.GraphGsonConfiguratorFactory;
@@ -42,7 +42,7 @@ import org.eclipse.glsp.api.registry.DiagramConfigurationRegistry;
 import org.eclipse.glsp.api.registry.NavigationTargetProviderRegistry;
 import org.eclipse.glsp.api.registry.OperationHandlerRegistry;
 import org.eclipse.glsp.api.registry.ServerCommandHandlerRegistry;
-import org.eclipse.glsp.server.action.DefaultActionProcessor;
+import org.eclipse.glsp.server.action.DefaultActionDispatcher;
 import org.eclipse.glsp.server.factory.DefaultGraphGsonConfiguratorFactory;
 import org.eclipse.glsp.server.jsonrpc.DefaultGLSPClientProvider;
 import org.eclipse.glsp.server.jsonrpc.DefaultGLSPServer;
@@ -121,8 +121,8 @@ public abstract class DefaultGLSPModule extends GLSPModule {
    }
 
    @Override
-   protected Class<? extends ActionProcessor> bindActionProcessor() {
-      return DefaultActionProcessor.class;
+   protected Class<? extends ActionDispatcher> bindActionDispatcher() {
+      return DefaultActionDispatcher.class;
    }
 
    @Override

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/MultiBindingDefaults.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/MultiBindingDefaults.java
@@ -28,6 +28,7 @@ import org.eclipse.glsp.api.action.kind.RequestBoundsAction;
 import org.eclipse.glsp.api.action.kind.SelectAction;
 import org.eclipse.glsp.api.action.kind.SelectAllAction;
 import org.eclipse.glsp.api.action.kind.ServerMessageAction;
+import org.eclipse.glsp.api.action.kind.ServerStatusAction;
 import org.eclipse.glsp.api.action.kind.SetBoundsAction;
 import org.eclipse.glsp.api.action.kind.SetClipboardDataAction;
 import org.eclipse.glsp.api.action.kind.SetContextActions;
@@ -99,6 +100,7 @@ public final class MultiBindingDefaults {
       SetPopupModelAction.class,
       SetResolvedNavigationTargetAction.class,
       SetTypeHintsAction.class,
+      ServerStatusAction.class,
       TriggerNodeCreationAction.class,
       TriggerEdgeCreationAction.class,
       UpdateModelAction.class);

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/jsonrpc/DefaultGLSPServer.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/jsonrpc/DefaultGLSPServer.java
@@ -21,14 +21,14 @@ import java.util.concurrent.CompletableFuture;
 
 import org.apache.log4j.Logger;
 import org.eclipse.glsp.api.action.ActionMessage;
-import org.eclipse.glsp.api.action.ActionProcessor;
+import org.eclipse.glsp.api.action.ActionDispatcher;
 import org.eclipse.glsp.api.jsonrpc.GLSPClient;
 import org.eclipse.glsp.api.jsonrpc.GLSPClientProvider;
 import org.eclipse.glsp.api.jsonrpc.GLSPServer;
 import org.eclipse.glsp.api.jsonrpc.InitializeParameters;
 import org.eclipse.glsp.api.model.ModelStateProvider;
-import org.eclipse.glsp.api.types.Severity;
 import org.eclipse.glsp.api.types.ServerStatus;
+import org.eclipse.glsp.api.types.Severity;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
@@ -42,7 +42,7 @@ public class DefaultGLSPServer<T> implements GLSPServer {
    @Inject
    protected GLSPClientProvider clientProxyProvider;
    @Inject
-   protected ActionProcessor actionProcessor;
+   protected ActionDispatcher actionDispatcher;
    private static Logger log = Logger.getLogger(DefaultGLSPServer.class);
 
    private ServerStatus status;
@@ -93,11 +93,11 @@ public class DefaultGLSPServer<T> implements GLSPServer {
          // is initialized. ClientId is only retrieved through messages; so this
          // is currently the earliest we can register the clientProxy
          this.clientProxyProvider.register(clientId, clientProxy);
-         actionProcessor.process(message);
+         actionDispatcher.dispatch(message);
       } catch (RuntimeException e) {
          String errorMsg = "Could not process message:" + message;
          log.error("[ERROR] " + errorMsg, e);
-         actionProcessor.send(clientId, error("[GLSP-Server] " + errorMsg, e));
+         actionDispatcher.dispatch(clientId, error("[GLSP-Server] " + errorMsg, e));
       }
    }
 

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operationhandler/CutOperationHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operationhandler/CutOperationHandler.java
@@ -17,7 +17,7 @@ package org.eclipse.glsp.server.operationhandler;
 
 import java.util.List;
 
-import org.eclipse.glsp.api.action.ActionProcessor;
+import org.eclipse.glsp.api.action.ActionDispatcher;
 import org.eclipse.glsp.api.model.GraphicalModelState;
 import org.eclipse.glsp.api.operation.kind.CutOperation;
 import org.eclipse.glsp.api.operation.kind.DeleteOperation;
@@ -27,13 +27,13 @@ import com.google.inject.Inject;
 public class CutOperationHandler extends BasicOperationHandler<CutOperation> {
 
    @Inject
-   protected ActionProcessor actionProcessor;
+   protected ActionDispatcher actionDispatcher;
 
    @Override
    public void executeOperation(final CutOperation operation, final GraphicalModelState modelState) {
       List<String> cutableElementIds = getElementToCut(operation, modelState);
       if (!cutableElementIds.isEmpty()) {
-         actionProcessor.process(modelState.getClientId(), new DeleteOperation(cutableElementIds));
+         actionDispatcher.dispatch(modelState.getClientId(), new DeleteOperation(cutableElementIds));
       }
    }
 


### PR DESCRIPTION
- Remove send() method: ActionProcessor.send() should only be called 
by the 'ClientActionHandler'. ActionHandlers that previously called the send()
method directly can now use process() instead.
- Rename `ActionProcessor` to `ActionDispatcher` (align with client side)

part of https://github.com/eclipse-glsp/glsp/issues/21