### PR TITLE
#95 Cleanup GLSPServerLauncher & add CLI parsing

### DIFF
--- a/plugins/org.eclipse.glsp.server.websocket/src/org/eclipse/glsp/server/websocket/WebsocketServerLauncher.java
+++ b/plugins/org.eclipse.glsp.server.websocket/src/org/eclipse/glsp/server/websocket/WebsocketServerLauncher.java
@@ -29,9 +29,6 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.websocket.jsr356.server.deploy.WebSocketServerContainerInitializer;
 
-import com.google.inject.Guice;
-import com.google.inject.Injector;
-
 public class WebsocketServerLauncher extends GLSPServerLauncher {
    private static Logger LOG = Logger.getLogger(WebsocketServerLauncher.class);
    private Server server;
@@ -41,6 +38,7 @@ public class WebsocketServerLauncher extends GLSPServerLauncher {
    public WebsocketServerLauncher(final GLSPModule module, final String endpointPath) {
       super(module);
       this.endpointPath = endpointPath.startsWith("/") ? endpointPath.substring(1) : endpointPath;
+      addAdditionalModules(new WebsocketModule());
    }
 
    public WebsocketServerLauncher(final GLSPModule module, final String endpointPath, final String clientAppPath) {
@@ -49,13 +47,8 @@ public class WebsocketServerLauncher extends GLSPServerLauncher {
    }
 
    @Override
-   protected Injector doSetup() {
-      return Guice.createInjector(getGLSPModule(), new WebsocketModule());
-   }
-
-   @Override
    @SuppressWarnings("checkstyle:IllegalCatch")
-   public void run(final String hostname, final int port) {
+   public void start(final String hostname, final int port) {
       try {
          // Setup Jetty Server
          server = new Server(new InetSocketAddress(hostname, port));
@@ -82,7 +75,7 @@ public class WebsocketServerLauncher extends GLSPServerLauncher {
          ServerContainer container = WebSocketServerContainerInitializer.configureContext(webAppContext);
          ServerEndpointConfig.Builder builder = ServerEndpointConfig.Builder.create(GLSPServerEndpoint.class,
             "/" + endpointPath);
-         builder.configurator(new GLSPConfigurator(getInjector()));
+         builder.configurator(new GLSPConfigurator(createInjector()));
          container.addEndpoint(builder.build());
 
          // Start the server

--- a/plugins/org.eclipse.glsp.server/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.server/META-INF/MANIFEST.MF
@@ -12,7 +12,8 @@ Require-Bundle: org.eclipse.glsp.api;bundle-version="0.7.0";visibility:=reexport
  com.google.gson;bundle-version="2.8.2",
  org.eclipse.lsp4j;bundle-version="0.7.0",
  org.eclipse.lsp4j.jsonrpc,
- com.google.guava;bundle-version="21.0.0"
+ com.google.guava;bundle-version="21.0.0",
+ org.apache.commons.cli;bundle-version="1.4.0";visibility:=reexport
 Import-Package: com.google.inject.multibindings;version="1.3.0"
 Export-Package: org.eclipse.glsp.server.actionhandler,
  org.eclipse.glsp.server.command,

--- a/plugins/org.eclipse.glsp.server/pom.xml
+++ b/plugins/org.eclipse.glsp.server/pom.xml
@@ -64,6 +64,11 @@
 			<artifactId>org.eclipse.emf.ecore.change</artifactId>
 			<version>2.14.0</version>
 		</dependency>
+		<dependency>
+			<groupId>commons-cli</groupId>
+			<artifactId>commons-cli</artifactId>
+			<version>1.4</version>
+		</dependency>
 	</dependencies>
 
 	<profiles>

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/launch/CLIParser.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/launch/CLIParser.java
@@ -1,0 +1,108 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.server.launch;
+
+import java.io.File;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.eclipse.glsp.server.utils.LaunchUtil;
+
+public final class CLIParser {
+   private static final Logger LOG = Logger.getLogger(CLIParser.class);
+   private final CommandLine cmd;
+   private final Options options;
+   private final String processName;
+
+   public CLIParser(final String[] args, final String processName) throws ParseException {
+      this(args, getDefaultCLIOptions(), processName);
+   }
+
+   public CLIParser(final String[] args, final Options options, final String processName) throws ParseException {
+      this.cmd = new DefaultParser().parse(options, args);
+      this.options = options;
+      this.processName = processName;
+   }
+
+   public boolean optionExists(final String identifier) {
+      return cmd.hasOption(identifier);
+   }
+
+   public Integer parsePort() {
+      String portArg = cmd.getOptionValue("p");
+      int port = LaunchUtil.DEFAULT_SERVER_PORT;
+      if (portArg != null) {
+         try {
+            port = Integer.parseInt(portArg);
+            if (!LaunchUtil.isValidPort(port)) {
+               throw new NumberFormatException();
+            }
+         } catch (NumberFormatException e) {
+            LOG.warn(String.format("'%s' is not a valid port! The default port '%s' is used",
+               portArg, LaunchUtil.DEFAULT_SERVER_PORT));
+         }
+      }
+
+      return port;
+   }
+
+   public String parseLogDir() {
+      String logDirArg = cmd.getOptionValue("d");
+      String logDir = LaunchUtil.DEFAULT_LOG_DIR;
+      if (logDirArg != null) {
+         File file = new File(logDirArg);
+         if (!file.exists() || !file.isDirectory()) {
+            LOG.warn(String.format("'%s' is not a valid directory! The default log path directory '%s' is used",
+               logDirArg, logDir));
+         } else {
+            logDir = file.getAbsolutePath();
+         }
+      }
+      return logDir;
+   }
+
+   public Level parseLogLevel() {
+      String levelArg = cmd.getOptionValue("ll");
+      return Level.toLevel(levelArg, LaunchUtil.DEFAULT_LOG_LEVEL);
+   }
+
+   public boolean isConsoleLog() { return optionExists("c"); }
+
+   public void printHelp() {
+      printHelp(this.processName, options);
+   }
+
+   public static void printHelp(final String processName, final Options options) {
+      HelpFormatter formatter = new HelpFormatter();
+      formatter.printHelp(90, processName, "\noptions:", options, "", true);
+   }
+
+   public static Options getDefaultCLIOptions() {
+      Options options = new Options();
+      options.addOption("h", "help", false, "Display usage information about GLSPServerLauncher");
+      options.addOption("p", "port", true,
+         String.format("Set server port, otherwise default port %s is used", LaunchUtil.DEFAULT_SERVER_PORT));
+      options.addOption("c", "consoleLog", false, "Print logout in console");
+      options.addOption("d", "logDir", true, "Set the directory for log files");
+      options.addOption("l", "logLevel", true, "Set the log level");
+      return options;
+   }
+}

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/launch/DefaultCLIParser.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/launch/DefaultCLIParser.java
@@ -1,0 +1,85 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.server.launch;
+
+import java.io.File;
+import java.util.function.Predicate;
+
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.log4j.Level;
+import org.eclipse.glsp.server.utils.LaunchUtil;
+import org.eclipse.glsp.server.utils.LaunchUtil.DefaultOptions;
+
+public class DefaultCLIParser extends CLIParser {
+   public static final String OPTION_HELP = "help";
+   public static final String OPTION_PORT = "port";
+   public static final String OPTION_CONSOLE_LOG = "consoleLog";
+   public static final String OPTION_FILE_LOG = "fileLog";
+   public static final String OPTION_LOG_LEVEL = "logLevel";
+   public static final String OPTION_LOG_DIR = "logDir";
+
+   public DefaultCLIParser(final String[] args, final String processName) throws ParseException {
+      this(args, getDefaultOptions(), processName);
+   }
+
+   public DefaultCLIParser(final String[] args, final Options options, final String processName) throws ParseException {
+      super(args, options, processName);
+   }
+
+   public int parsePort() {
+      Predicate<Integer> validator = (port) -> LaunchUtil.isValidPort(port);
+      return parseIntOption(OPTION_PORT, DefaultOptions.SERVER_PORT, validator);
+   }
+
+   public String parseLogDir() {
+      Predicate<String> validator = (logDirArg) -> {
+         File file = new File(logDirArg);
+         return file.exists() && file.isDirectory();
+      };
+      String logDir = parseOption(OPTION_LOG_DIR, DefaultOptions.LOG_DIR, validator);
+      return new File(logDir).getAbsolutePath();
+   }
+
+   public Level parseLogLevel() {
+      String levelArg = parseOption(OPTION_LOG_LEVEL, DefaultOptions.LOG_LEVEL.toString());
+      return Level.toLevel(levelArg, DefaultOptions.LOG_LEVEL);
+   }
+
+   public boolean isConsoleLog() { return parseBoolOption(OPTION_CONSOLE_LOG, DefaultOptions.CONSOLE_LOG_ENABLED); }
+
+   public boolean isFileLog() { return parseBoolOption(OPTION_FILE_LOG, DefaultOptions.FILE_LOG_ENABLED); }
+
+   public boolean isHelp() { return hasOption(OPTION_HELP); }
+
+   public static Options getDefaultOptions() {
+      Options options = new Options();
+      options.addOption(null, OPTION_HELP, false, "Display usage information about GLSPServerLauncher");
+      options.addOption(null, OPTION_PORT, true,
+         String.format("Set server port. [default='%s']", DefaultOptions.SERVER_PORT));
+      options.addOption(null, OPTION_CONSOLE_LOG, true,
+         String.format("Enable/Disable console logging. [default='%s']", DefaultOptions.CONSOLE_LOG_ENABLED));
+      options.addOption(null, OPTION_FILE_LOG, true,
+         String.format("Enable/Disable file logging. [default='%s']", DefaultOptions.FILE_LOG_ENABLED));
+      options.addOption(null, OPTION_LOG_DIR, true,
+         String.format("Set the directory for log files (File logging has to be enabled). [default='%s']",
+            DefaultOptions.LOG_DIR));
+      options.addOption(null, OPTION_LOG_LEVEL, true,
+         String.format("Set the log level. [default='%s']", DefaultOptions.LOG_LEVEL));
+      return options;
+   }
+
+}

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/launch/GLSPServerLauncher.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/launch/GLSPServerLauncher.java
@@ -15,40 +15,40 @@
  ********************************************************************************/
 package org.eclipse.glsp.server.launch;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.eclipse.glsp.api.di.GLSPModule;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.Module;
 
 public abstract class GLSPServerLauncher {
 
-   private GLSPModule module;
-   private Injector injector;
+   private final GLSPModule glspModule;
+   private final List<Module> modules;
 
-   public GLSPServerLauncher() {}
-
-   public GLSPServerLauncher(final GLSPModule module) {
-      this.module = module;
+   public GLSPServerLauncher(final GLSPModule glspModule) {
+      this.glspModule = glspModule;
+      modules = new ArrayList<>();
+      modules.add(glspModule);
    }
 
-   protected Injector doSetup() {
-      return Guice.createInjector(module);
+   public void addAdditionalModules(final Module... modules) {
+      Arrays.stream(modules)
+         .filter(module -> !this.modules.contains(module))
+         .forEach(this.modules::add);
    }
 
-   public void start(final String hostname, final int port) {
-      if (injector == null) {
-         injector = doSetup();
-      }
-      run(hostname, port);
+   public Injector createInjector() {
+      return Guice.createInjector(modules);
    }
 
-   protected abstract void run(String hostname, int port);
+   public abstract void start(String hostname, int port);
 
    public abstract void shutdown();
 
-   public GLSPModule getGLSPModule() { return module; }
-
-   public Injector getInjector() { return injector; }
-
-   public void setModule(final GLSPModule module) { this.module = module; }
+   public GLSPModule getGLSPModule() { return glspModule; }
 }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/utils/LaunchUtil.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/utils/LaunchUtil.java
@@ -1,0 +1,81 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.server.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import org.apache.commons.cli.ParseException;
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.FileAppender;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
+import org.eclipse.glsp.server.launch.CLIParser;
+
+public final class LaunchUtil {
+   private LaunchUtil() {}
+
+   public static final int DEFAULT_SERVER_PORT = 5007;
+   public static final Level DEFAULT_LOG_LEVEL = Level.INFO;
+   public static final String DEFAULT_LOG_DIR = new File("./logs/").getAbsolutePath();
+
+   public static boolean isValidPort(final Integer port) {
+      return port >= 0 && port <= 65535;
+   }
+
+   public static void configureConsoleLogger() {
+      configureConsoleLogger(DEFAULT_LOG_LEVEL);
+   }
+
+   public static void configureConsoleLogger(final Level logLevel) {
+      Logger root = Logger.getRootLogger();
+      if (!root.getAllAppenders().hasMoreElements()) {
+         root.addAppender(new ConsoleAppender(
+            new PatternLayout(PatternLayout.TTCC_CONVERSION_PATTERN)));
+      }
+      root.setLevel(logLevel);
+
+   }
+
+   public static void configureLogger(
+      final CLIParser parser) throws ParseException, IOException {
+      if (parser.isConsoleLog()) {
+         configureConsoleLogger();
+      } else {
+         String logDir = parser.parseLogDir();
+         SimpleDateFormat formatter = new SimpleDateFormat("dd-MM-yyyy_HH:mm:ss");
+         String fileName = formatter.format(new Date()) + ".log";
+         File logFile = new File(logDir, fileName);
+         Level level = parser.parseLogLevel();
+         configureLogger(logFile.getAbsolutePath(), level);
+      }
+   }
+
+   public static void configureLogger(final String logFile) throws IOException {
+      configureLogger(logFile, DEFAULT_LOG_LEVEL);
+   }
+
+   public static void configureLogger(final String logFile, final Level logLevel) throws IOException {
+      Logger root = Logger.getRootLogger();
+      root.removeAllAppenders();
+      root.addAppender(
+         new FileAppender(new PatternLayout(PatternLayout.TTCC_CONVERSION_PATTERN), logFile));
+   }
+
+}

--- a/targetplatforms/r2020-06.target
+++ b/targetplatforms/r2020-06.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="2020-06 - Release" sequenceNumber="1593006377">
+<target name="2020-06 - Release" sequenceNumber="1597185458">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.2.600.v20200521-1852"/>
@@ -11,6 +11,7 @@
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.apache.log4j" version="1.2.15.v201012070815"/>
+      <unit id="org.apache.commons.cli" version="1.4.0.v20200417-1444"/>
       <unit id="org.apache.commons.io" version="2.6.0.v20190123-2029"/>
       <unit id="javax.servlet" version="3.1.0.v201410161800"/>
       <unit id="com.google.gson" version="2.8.2.v20180104-1110"/>

--- a/targetplatforms/r2020-06.tpd
+++ b/targetplatforms/r2020-06.tpd
@@ -8,6 +8,7 @@ location "http://download.eclipse.org/releases/2020-06" {
 
 location "https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository/" {
 	org.apache.log4j
+	org.apache.commons.cli
 	org.apache.commons.io
 	javax.servlet
 	com.google.gson [2.8.2,3.0.0)


### PR DESCRIPTION
- Cleanup GLSPServerLauncher (refactor methods & add support to inject additional modules)
- Add a CLIParser helper class and configure default options for configuring
- - Server port
- - consoleLog flag
- - logging directory
- - logLevel
- - help

Fixes eclipse-glsp/glsp/issues/95