### PR TITLE
#101 Ensure proper handling of empty DeleteElementOperation

### DIFF
--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operationhandler/DeleteOperationHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operationhandler/DeleteOperationHandler.java
@@ -42,7 +42,8 @@ public class DeleteOperationHandler extends BasicOperationHandler<DeleteOperatio
    public void executeOperation(final DeleteOperation operation, final GraphicalModelState modelState) {
       List<String> elementIds = operation.getElementIds();
       if (elementIds == null || elementIds.size() == 0) {
-         throw new IllegalArgumentException("Elements to delete are not specified");
+         log.warn("Elements to delete are not specified");
+         return;
       }
       GModelIndex index = modelState.getIndex();
       allDependantsIds = new HashSet<>();


### PR DESCRIPTION
Log a warning instead of throwing an exception if no elementIds are specified for an DeleteElementAction.
Throwing an exception here will break the command stack. In addition, it's not necessary because technically an empty DeleteElementOperation is still valid (and simply does not affect the model at all)

Fixes eclipse-glsp/glsp/issues/101