### PR TITLE
#97 ActionDispatcher should process all messages in the same thread

### DIFF
--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/ActionDispatcher.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/ActionDispatcher.java
@@ -16,6 +16,8 @@
 package org.eclipse.glsp.api.action;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 public interface ActionDispatcher {
 
@@ -23,9 +25,11 @@ public interface ActionDispatcher {
     * @see ActionDispatcher#dispatch(String, Action)
     *
     * @param message ActionMessage received from the client
+    * @return
+    *         A {@link CompletableFuture} indicating when the action processing is complete
     */
-   default void dispatch(final ActionMessage message) {
-      dispatch(message.getClientId(), message.getAction());
+   default CompletableFuture<Void> dispatch(final ActionMessage message) {
+      return dispatch(message.getClientId(), message.getAction());
    }
 
    /**
@@ -35,8 +39,10 @@ public interface ActionDispatcher {
     *
     * @param clientId The client from which the action was received
     * @param action   The action to dispatch
+    * @return
+    *         A {@link CompletableFuture} indicating when the action processing is complete
     */
-   void dispatch(String clientId, Action action);
+   CompletableFuture<Void> dispatch(String clientId, Action action);
 
    /**
     * <p>
@@ -45,16 +51,17 @@ public interface ActionDispatcher {
     *
     * @param clientId
     * @param actions
+    * @return A list of {@link CompletableFuture CompletableFutures}; one for each dispatched action
     */
-   default void dispatchAll(final String clientId, final List<Action> actions) {
-      actions.forEach(action -> dispatch(clientId, action));
+   default List<CompletableFuture<Void>> dispatchAll(final String clientId, final List<Action> actions) {
+      return actions.stream().map(action -> dispatch(clientId, action)).collect(Collectors.toList());
    }
 
    class NullImpl implements ActionDispatcher {
 
       @Override
-      public void dispatch(final String clientId, final Action action) {
-         return;
+      public CompletableFuture<Void> dispatch(final String clientId, final Action action) {
+         return CompletableFuture.completedFuture(null);
       }
    }
 }

--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/protocol/GLSPServer.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/protocol/GLSPServer.java
@@ -27,4 +27,6 @@ public interface GLSPServer<T extends GLSPClient> {
    CompletableFuture<Boolean> shutdown();
 
    void connect(T client);
+
+   T getClient();
 }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/action/DefaultActionDispatcher.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/action/DefaultActionDispatcher.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019 EclipseSource and others.
+ * Copyright (c) 2019-2020 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,44 +15,198 @@
  ********************************************************************************/
 package org.eclipse.glsp.server.action;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import org.apache.log4j.Logger;
 import org.eclipse.glsp.api.action.Action;
 import org.eclipse.glsp.api.action.ActionDispatcher;
+import org.eclipse.glsp.api.action.ActionMessage;
 import org.eclipse.glsp.api.action.kind.ResponseAction;
 import org.eclipse.glsp.api.handler.ActionHandler;
 import org.eclipse.glsp.api.model.GraphicalModelState;
 import org.eclipse.glsp.api.model.ModelStateProvider;
+import org.eclipse.glsp.api.protocol.ClientSessionListener;
+import org.eclipse.glsp.api.protocol.ClientSessionManager;
+import org.eclipse.glsp.api.protocol.GLSPClient;
 import org.eclipse.glsp.api.registry.ActionHandlerRegistry;
 
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
-public class DefaultActionDispatcher implements ActionDispatcher {
-   private static Logger LOG = Logger.getLogger(DefaultActionDispatcher.class);
+/**
+ * <p>
+ * An ActionDispatcher that executes all handlers in the same thread. The dispatcher's
+ * public methods can be invoked from any thread, e.g. from background jobs running on
+ * the server.
+ * </p>
+ */
+public class DefaultActionDispatcher implements ActionDispatcher, ClientSessionListener {
+
+   private static final Logger LOG = Logger.getLogger(DefaultActionDispatcher.class);
+
+   private static final AtomicInteger COUNT = new AtomicInteger(0);
 
    @Inject
-   protected ActionHandlerRegistry actionHandlerRegistry;
+   private ActionHandlerRegistry actionHandlerRegistry;
 
    @Inject
-   protected ModelStateProvider modelStateProvider;
+   private ModelStateProvider modelStateProvider;
+
+   private final ClientSessionManager clientSessionManager;
+
+   private final String name;
+
+   private final Thread thread;
+
+   private final BlockingQueue<ActionMessage> actionsQueue = new ArrayBlockingQueue<>(100, true);
+
+   // Results will be placed in the map when the action dispatcher receives a new message (From arbitrary threads),
+   // and will be removed from the dispatcher's thread.
+   private final Map<ActionMessage, CompletableFuture<Void>> results = Collections.synchronizedMap(new HashMap<>());
+
+   // Use a provider, as the GLSPClient is probably not created yet. We won't receive
+   // any message until it's ready anyway.
+   @Inject
+   private Provider<GLSPClient> client;
+
+   @Inject
+   public DefaultActionDispatcher(final ClientSessionManager clientSessionManager) {
+      this.name = getClass().getSimpleName() + " " + COUNT.incrementAndGet();
+      this.clientSessionManager = clientSessionManager;
+      this.clientSessionManager.addListener(this);
+      this.thread = new Thread(this::runThread);
+      this.thread.setName(this.name);
+      this.thread.setDaemon(true);
+      this.thread.start();
+   }
 
    @Override
-   public void dispatch(final String clientId, final Action action) {
-      List<ActionHandler> actionHandlers = actionHandlerRegistry.get(action);
-      if (actionHandlers.isEmpty()) {
-         LOG.warn("No handler registered for action: " + action);
+   public CompletableFuture<Void> dispatch(final String clientId, final Action action) {
+      return dispatch(new ActionMessage(clientId, action));
+   }
+
+   @Override
+   public CompletableFuture<Void> dispatch(final ActionMessage message) {
+      if (message == null) {
+         String errorMsg = String.format("Received a null message in DefaultActionDispatcher: %s", name);
+         throw new IllegalArgumentException(errorMsg);
+      }
+      final CompletableFuture<Void> result = results.putIfAbsent(message, new CompletableFuture<Void>());
+      if (thread == Thread.currentThread()) {
+         // Actions dispatched from the ActionDispatcher thread don't have to go back
+         // to the queue, as they are just fragments of the current action from the queue.
+         // Process them immediately.
+         handleMessage(message);
+      } else {
+         addToQueue(message);
+      }
+      return result;
+   }
+
+   private void addToQueue(final ActionMessage message) {
+      if (Thread.currentThread() == this.thread) {
+         LOG.error("ActionMessages shouldn't be added to the actions queue from the dispatcher thread!");
+         // Handle the message immediately, to avoid deadlocks when the queue if full
+         handleMessage(message);
          return;
       }
-      GraphicalModelState modelState = modelStateProvider.getModelState(clientId)
+      boolean success = actionsQueue.offer(message);
+      while (!success) {
+         if (!thread.isAlive() || thread.isInterrupted()) {
+            // This may happen if e.g. some background tasks were still running when the client disconnected.
+            // This (probably) isn't critical and can be safely ignored.
+            LOG.warn(String.format(
+               "Received an action message after the ActionDispatcher was stopped. Ignoring message: %s", message));
+            return;
+         }
+         try {
+            // The queue may be temporarily full because we receive a lot of messages (e.g. during initialization),
+            // but if this keeps failing for a long time, it might indicate a deadlock
+            success = actionsQueue.offer(message, 1, TimeUnit.SECONDS);
+            if (!success) {
+               LOG.warn(String.format("Actions queue is currently full for dispatcher %s ; retrying...", name));
+            }
+         } catch (final InterruptedException ex) {
+            break;
+         }
+      }
+   }
+
+   private void runThread() {
+      while (true) {
+         try {
+            handleNextMessage();
+         } catch (final InterruptedException e) {
+            LOG.info(String.format("Terminating DefaultActionDispatcher thread %s", Thread.currentThread().getName()));
+            break;
+         }
+      }
+      LOG.info("Terminating DefaultActionDispatcher");
+   }
+
+   private void handleNextMessage()
+      throws InterruptedException {
+      final ActionMessage message = actionsQueue.take();
+      if (message != null) {
+         handleMessage(message);
+      }
+   }
+
+   private void handleMessage(final ActionMessage message) {
+      checkThread();
+      final Action action = message.getAction();
+      final String clientId = message.getClientId();
+      if (action == null) {
+         LOG.warn(String.format("Received an action message without an action for client %s", clientId));
+         return;
+      }
+
+      try {
+         runAction(action, clientId);
+         results.remove(message).complete(null);
+      } catch (Throwable t) {
+         results.remove(message).completeExceptionally(t);
+      }
+   }
+
+   private void runAction(final Action action, final String clientId) {
+      final List<ActionHandler> actionHandlers = actionHandlerRegistry.get(action);
+      if (actionHandlers.isEmpty()) {
+         throw new IllegalArgumentException("No handler registered for action: " + action);
+      }
+      final GraphicalModelState modelState = modelStateProvider.getModelState(clientId)
          .orElseGet(() -> modelStateProvider.create(clientId));
 
-      for (ActionHandler actionHandler : actionHandlers) {
-         List<Action> responses = actionHandler.execute(action, modelState).stream()
+      for (final ActionHandler actionHandler : actionHandlers) {
+         final List<Action> responses = actionHandler.execute(action, modelState).stream()
             .map(response -> ResponseAction.respond(action, response))
             .collect(Collectors.toList());
          dispatchAll(clientId, responses);
       }
    }
+
+   private void checkThread() {
+      if (Thread.currentThread() != thread) {
+         throw new IllegalStateException(
+            "This method should only be invoked from the ActionDispatcher's thread: " + name);
+      }
+   }
+
+   @Override
+   public void clientDisconnected(final GLSPClient client) {
+      if (client == this.client.get()) {
+         this.thread.interrupt();
+         this.clientSessionManager.removeListener(this);
+      }
+   }
+
 }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/GLSPModule.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/GLSPModule.java
@@ -28,6 +28,7 @@ import org.eclipse.glsp.api.markers.ModelValidator;
 import org.eclipse.glsp.api.model.ModelStateProvider;
 import org.eclipse.glsp.api.model.NavigationTargetResolver;
 import org.eclipse.glsp.api.protocol.ClientSessionManager;
+import org.eclipse.glsp.api.protocol.GLSPClient;
 import org.eclipse.glsp.api.protocol.GLSPServer;
 import org.eclipse.glsp.api.provider.CommandPaletteActionProvider;
 import org.eclipse.glsp.api.provider.ContextMenuItemProvider;
@@ -43,6 +44,7 @@ import org.eclipse.glsp.api.registry.ServerCommandHandlerRegistry;
 import org.eclipse.glsp.graph.GraphExtension;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
 import com.google.inject.Singleton;
 
 public abstract class GLSPModule extends AbstractModule {
@@ -50,7 +52,7 @@ public abstract class GLSPModule extends AbstractModule {
    @Override
    protected void configure() {
       // Configure default bindings
-      bind(GLSPServer.class).to(bindGLSPServer());
+      bind(GLSPServer.class).to(bindGLSPServer()).in(Singleton.class);
       bind(PopupModelFactory.class).to(bindPopupModelFactory());
       bind(ModelFactory.class).to(bindModelFactory());
       bind(ILayoutEngine.class).to(bindLayoutEngine());
@@ -147,5 +149,10 @@ public abstract class GLSPModule extends AbstractModule {
 
    protected Class<? extends GraphExtension> bindGraphExtension() {
       return null;
+   }
+
+   @Provides
+   private GLSPClient getGLSPClient(final GLSPServer glspServer) {
+      return glspServer.getClient();
    }
 }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/jsonrpc/DefaultClientSessionManager.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/jsonrpc/DefaultClientSessionManager.java
@@ -15,6 +15,7 @@
  ********************************************************************************/
 package org.eclipse.glsp.server.jsonrpc;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -42,7 +43,7 @@ public final class DefaultClientSessionManager implements ClientSessionManager {
    public synchronized boolean connectClient(final GLSPClient client) {
       boolean success = clients.add(client);
       if (success) {
-         listeners.forEach(listener -> listener.clientConnected(client));
+         new ArrayList<>(this.listeners).forEach(listener -> listener.clientConnected(client));
       }
       return success;
    }
@@ -52,7 +53,7 @@ public final class DefaultClientSessionManager implements ClientSessionManager {
       connectClient(client);
       boolean success = clientSessions.putIfAbsent(clientId, client) == null;
       if (success) {
-         listeners.forEach(listener -> listener.sessionCreated(clientId, client));
+         new ArrayList<>(this.listeners).forEach(listener -> listener.sessionCreated(clientId, client));
       }
       return success;
    }
@@ -61,7 +62,7 @@ public final class DefaultClientSessionManager implements ClientSessionManager {
    public synchronized boolean disposeClientSession(final String clientId) {
       GLSPClient client = clientSessions.remove(clientId);
       if (client != null) {
-         listeners.forEach(listener -> listener.sessionClosed(clientId, client));
+         new ArrayList<>(this.listeners).forEach(listener -> listener.sessionClosed(clientId, client));
          return true;
       }
       return false;
@@ -77,7 +78,7 @@ public final class DefaultClientSessionManager implements ClientSessionManager {
 
          sessionsToDisconnect.forEach(this::disposeClientSession);
          this.clients.remove(client);
-         this.listeners.forEach(listener -> listener.clientDisconnected(client));
+         new ArrayList<>(this.listeners).forEach(listener -> listener.clientDisconnected(client));
          return true;
       }
       return false;


### PR DESCRIPTION
- Refactor the ActionDispatcher to use an actions queue. Update the API to return CompletableFutures, as the method is now asynchronous.
- Expose the GLSPClient through the injector (Delegating to the GLSPServer)
- Fix some concurrent modification exceptions in DefaultClientSessionManager

fixes eclipse-glsp/glsp/issues/97