### PR TITLE
#109 Remove the UUID requirement / ApplicationID

### DIFF
--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/protocol/ClientSessionManager.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/protocol/ClientSessionManager.java
@@ -15,15 +15,13 @@
  ********************************************************************************/
 package org.eclipse.glsp.api.protocol;
 
-import java.util.Optional;
-
 public interface ClientSessionManager {
 
    boolean connectClient(GLSPClient client);
 
    boolean createClientSession(GLSPClient glspClient, String clientId);
 
-   boolean disposeClientSession(String clientId);
+   boolean disposeClientSession(GLSPClient client, String clientId);
 
    boolean disconnectClient(GLSPClient client);
 
@@ -31,5 +29,4 @@ public interface ClientSessionManager {
 
    boolean removeListener(ClientSessionListener listener);
 
-   Optional<GLSPClient> resolve(String clientId);
 }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actionhandler/DisposeClientSessionActionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actionhandler/DisposeClientSessionActionHandler.java
@@ -21,17 +21,22 @@ import org.eclipse.glsp.api.action.Action;
 import org.eclipse.glsp.api.action.kind.DisposeClientSessionAction;
 import org.eclipse.glsp.api.model.GraphicalModelState;
 import org.eclipse.glsp.api.protocol.ClientSessionManager;
+import org.eclipse.glsp.api.protocol.GLSPClient;
 
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 public class DisposeClientSessionActionHandler extends BasicActionHandler<DisposeClientSessionAction> {
 
-   @Inject()
+   @Inject
    protected ClientSessionManager sessionManager;
+
+   @Inject
+   protected Provider<GLSPClient> client;
 
    @Override
    protected List<Action> executeAction(final DisposeClientSessionAction action, final GraphicalModelState modelState) {
-      sessionManager.disposeClientSession(action.getClientId());
+      sessionManager.disposeClientSession(client.get(), action.getClientId());
       return none();
    }
 

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/jsonrpc/DefaultClientSessionManager.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/jsonrpc/DefaultClientSessionManager.java
@@ -48,7 +48,7 @@ public final class DefaultClientSessionManager implements ClientSessionManager {
    @Override
    public synchronized boolean createClientSession(final GLSPClient client, final String clientId) {
       connectClient(client);
-      boolean success = clientSessions.computeIfAbsent(client, c -> new HashSet<>()).add(clientId);
+      boolean success = clientSessions.get(client).add(clientId);
       if (success) {
          new ArrayList<>(this.listeners).forEach(listener -> listener.sessionCreated(clientId, client));
       }


### PR DESCRIPTION
- Remove the clientId to GLSPClient mapping in ClientSessionManager

fixes eclipse-glsp/glsp/issues/109

Signed-off-by: Camille Letavernier <cletavernier@eclipsesource.com>