### PR TITLE
Fix errorHandling in GLPSDefaultServer

### DIFF
--- a/plugins/org.eclipse.glsp.server/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.server/META-INF/MANIFEST.MF
@@ -15,7 +15,8 @@ Require-Bundle: org.eclipse.glsp.api;bundle-version="0.7.0";visibility:=reexport
  org.apache.commons.cli;bundle-version="1.4.0";visibility:=reexport,
  com.google.inject;bundle-version="3.0.0";visibility:=reexport
 Import-Package: com.google.inject.multibindings;version="1.3.0"
-Export-Package: org.eclipse.glsp.server.actionhandler,
+Export-Package: org.eclipse.glsp.server.action,
+ org.eclipse.glsp.server.actionhandler,
  org.eclipse.glsp.server.command,
  org.eclipse.glsp.server.di,
  org.eclipse.glsp.server.factory,

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/action/DefaultActionDispatcher.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/action/DefaultActionDispatcher.java
@@ -39,9 +39,8 @@ import org.eclipse.glsp.api.model.ModelStateProvider;
 import org.eclipse.glsp.api.protocol.ClientSessionListener;
 import org.eclipse.glsp.api.protocol.ClientSessionManager;
 import org.eclipse.glsp.api.protocol.GLSPClient;
+import org.eclipse.glsp.api.protocol.GLSPServerException;
 import org.eclipse.glsp.api.registry.ActionHandlerRegistry;
-import org.eclipse.glsp.api.utils.ServerMessageUtil;
-import org.eclipse.glsp.api.utils.ServerStatusUtil;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -199,10 +198,7 @@ public class DefaultActionDispatcher implements ActionDispatcher, ClientSessionL
             String errorMsg = String.format(
                "The session for client '%s' has not been initialized yet. Could not process action: %s", clientId,
                action);
-            LOG.error(errorMsg);
-            this.client.get().process(new ActionMessage(clientId, ServerStatusUtil.error(errorMsg)));
-            this.client.get().process(new ActionMessage(clientId, ServerMessageUtil.error(errorMsg)));
-            return;
+            throw new GLSPServerException(errorMsg);
          }
       }
 

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/jsonrpc/DefaultGLSPServer.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/jsonrpc/DefaultGLSPServer.java
@@ -102,7 +102,7 @@ public class DefaultGLSPServer<T> implements GLSPJsonrpcServer {
       Function<Throwable, Void> errorHandler = ex -> {
          String errorMsg = "Could not process message:" + message;
          log.error("[ERROR] " + errorMsg, ex);
-         actionDispatcher.dispatch(clientId, error("[GLSP-Server] " + errorMsg, ex));
+         getClient().process(new ActionMessage(clientId, error("[GLSP-Server] " + errorMsg, ex)));
          return null;
       };
       try {


### PR DESCRIPTION
Directly use clientProxy in errorHandler instead of  the actionDispatcher (ActionDispatcher only works if server and session were properly initialized).