### PR TITLE
#123 Centralize configuration in the server

### DIFF
--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/Action.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/Action.java
@@ -82,5 +82,6 @@ public abstract class Action {
       public static final String UNDO = "glspUndo";
       public static final String UPDATE_MODEL = "updateModel";
       public static final String VALIDATE_LABEL_EDIT_ACTION = "validateLabelEdit";
+      public static final String CONFIGURE_SERVER_HANDLERS = "configureServerHandlers";
    }
 }

--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/kind/ConfigureServerHandlersAction.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/kind/ConfigureServerHandlersAction.java
@@ -1,0 +1,49 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.api.action.kind;
+
+import java.util.Collection;
+import java.util.Set;
+
+import org.eclipse.glsp.api.action.Action;
+
+/**
+ * An Action to notify the client about the list of actions that the server
+ * can handle. With this, the client doesn't need to be manually configured
+ * to distinguish between client-side actions and server-side actions; adding
+ * a new Action Handler on the server configuration is sufficient.
+ */
+public class ConfigureServerHandlersAction extends Action {
+
+   public static final String ACTION_HANDLERS = "actionHandlers";
+   public static final String OPERATION_HANDLERS = "operationHandlers";
+
+   private Collection<String> actionKinds;
+
+   public ConfigureServerHandlersAction() {
+      super(Action.Kind.CONFIGURE_SERVER_HANDLERS);
+   }
+
+   public ConfigureServerHandlersAction(final Set<String> allServerActions) {
+      this();
+      actionKinds = allServerActions;
+   }
+
+   public void setActions(final Collection<String> actionKinds) { this.actionKinds = actionKinds; }
+
+   public Collection<String> getActionKinds() { return actionKinds; }
+
+}

--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/kind/InitializeClientSessionAction.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/action/kind/InitializeClientSessionAction.java
@@ -16,7 +16,24 @@
 package org.eclipse.glsp.api.action.kind;
 
 import org.eclipse.glsp.api.action.Action;
+import org.eclipse.glsp.api.protocol.ClientSessionListener;
+import org.eclipse.glsp.api.protocol.ClientSessionManager;
 
+/**
+ * Initialize a new session. One client may open several sessions.
+ * Each session is associated to a unique clientId. The session
+ * is used to track the client lifecycle: it should be the first
+ * action sent by a client to the server. The server will then
+ * be able to dispose any resources associated to this client when
+ * either:
+ * <ol>
+ * <li>the client disconnects</li>
+ * <li>the client sends a DisposeClientSessionAction</li>
+ * </ol>
+ *
+ * @see ClientSessionManager
+ * @see ClientSessionListener
+ */
 public class InitializeClientSessionAction extends Action {
 
    private String clientId;

--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/registry/MapRegistry.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/registry/MapRegistry.java
@@ -53,6 +53,11 @@ public abstract class MapRegistry<K, V> implements Registry<K, V> {
    @Override
    public Set<V> getAll() { return new HashSet<>(elements.values()); }
 
+   @Override
+   public Set<K> keys() {
+      return new HashSet<>(elements.keySet());
+   }
+
    protected GLSPServerException missing(final K key) {
       return new GLSPServerException("Unknown registry key: " + key);
    }

--- a/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/registry/Registry.java
+++ b/plugins/org.eclipse.glsp.api/src/org/eclipse/glsp/api/registry/Registry.java
@@ -29,4 +29,6 @@ public interface Registry<K, V> {
    Optional<V> get(K key);
 
    Set<V> getAll();
+
+   Set<K> keys();
 }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actionhandler/InitializeClientSessionActionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actionhandler/InitializeClientSessionActionHandler.java
@@ -15,37 +15,28 @@
  ********************************************************************************/
 package org.eclipse.glsp.server.actionhandler;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import org.apache.log4j.Logger;
 import org.eclipse.glsp.api.action.Action;
 import org.eclipse.glsp.api.action.kind.ConfigureServerHandlersAction;
 import org.eclipse.glsp.api.action.kind.InitializeClientSessionAction;
-import org.eclipse.glsp.api.handler.ActionHandler;
-import org.eclipse.glsp.api.handler.OperationHandler;
 import org.eclipse.glsp.api.model.GraphicalModelState;
 import org.eclipse.glsp.api.protocol.ClientSessionManager;
 import org.eclipse.glsp.api.protocol.GLSPClient;
 import org.eclipse.glsp.api.protocol.GLSPServerException;
+import org.eclipse.glsp.api.registry.ActionRegistry;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import com.google.inject.name.Named;
 
 /**
  * Initializes the lifecycle for a ClientSession via the {@link ClientSessionManager},
  * and notifies the client about all actions that this server can handle.
  */
 public class InitializeClientSessionActionHandler extends BasicActionHandler<InitializeClientSessionAction> {
-
-   private static Logger LOG = Logger.getLogger(InitializeClientSessionActionHandler.class);
 
    @Inject
    protected ClientSessionManager clientSessionManager;
@@ -54,10 +45,11 @@ public class InitializeClientSessionActionHandler extends BasicActionHandler<Ini
    protected Provider<GLSPClient> client;
 
    @Inject
-   protected Provider<Set<ActionHandler>> serverActions;
+   protected Provider<ActionRegistry> actionRegistry;
 
    @Inject
-   protected Provider<Set<OperationHandler>> serverOperations;
+   @Named(ClientActionHandler.CLIENT_ACTIONS)
+   protected Provider<Set<Action>> clientActions;
 
    @Override
    protected List<Action> executeAction(final InitializeClientSessionAction action,
@@ -65,68 +57,16 @@ public class InitializeClientSessionActionHandler extends BasicActionHandler<Ini
       if (clientSessionManager.createClientSession(client.get(), action.getClientId())) {
          modelState.setClientId(action.getClientId());
       } else {
-         throw new GLSPServerException(String.format(
-            "Could not create session for client id '%s'. Another session with the same id already exists",
-            action.getClientId()));
+         throw new GLSPServerException(String.format("Could not create session for client id '%s'. "
+            + "Another session with the same id already exists", action.getClientId()));
       }
-
       return listOf(configureServerHandlers());
    }
 
-   private Action configureServerHandlers() {
-      Set<String> actions = serverActions.get().stream()
-         .flatMap(handler -> getActionKinds(handler).stream())
-         .filter(Objects::nonNull)
-         .collect(Collectors.toSet());
-      Set<String> operations = serverOperations.get().stream()
-         .map(this::getActionKind)
-         .filter(Objects::nonNull)
-         .collect(Collectors.toSet());
-
-      Set<String> allServerActions = Stream.concat(actions.stream(), operations.stream())
-         .collect(Collectors.toSet());
-
-      return new ConfigureServerHandlersAction(allServerActions);
-   }
-
-   protected Collection<String> getActionKinds(final ActionHandler actionHandler) {
-      if (actionHandler instanceof OperationActionHandler) {
-         // This is a special case, which delegates operations to operation handlers. As such,
-         // we can't determine its action kinds (But we'll retrieve all operation kinds in the next
-         // step anyway)
-         return Collections.emptyList();
-      }
-
-      List<String> actionKinds = actionHandler.getHandledActionTypes().stream().map(this::getActionKind)
-         .collect(Collectors.toList());
-      if (actionKinds.stream().anyMatch(Objects::isNull)) {
-         LOG.error("Unable to determine all action kinds for ActionHandler: " + actionHandler);
-      }
-      return actionKinds;
-   }
-
-   protected String getActionKind(final OperationHandler operationHandler) {
-      String actionKind = getActionKind(operationHandler.getHandledOperationType());
-      if (actionKind == null) {
-         LOG.error("Unable to determine action kind for OperationHandler: " + operationHandler);
-      }
-      return actionKind;
-   }
-
-   protected String getActionKind(final Class<? extends Action> actionClass) {
-      try {
-         Constructor<?> declaredConstructor = actionClass.getDeclaredConstructor();
-         Action a = actionClass.cast(declaredConstructor.newInstance());
-         return a.getKind();
-      } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | IllegalArgumentException
-         | InvocationTargetException ex) {
-         // Action doesn't have a valid 0-arg constructor, so we can't automatically determine the action kind.
-         // Extensions may need to override this method to handle this case.
-         LOG.error(
-            "Unable to determine the action kind for class " + actionClass + ". Manual declaration may be required.",
-            ex);
-         return null;
-      }
+   protected Action configureServerHandlers() {
+      final Set<String> actionKinds = actionRegistry.get().keys();
+      actionKinds.removeAll(clientActions.get().stream().map(Action::getKind).collect(Collectors.toSet()));
+      return new ConfigureServerHandlersAction(actionKinds);
    }
 
 }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actionhandler/InitializeClientSessionActionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actionhandler/InitializeClientSessionActionHandler.java
@@ -15,10 +15,22 @@
  ********************************************************************************/
 package org.eclipse.glsp.server.actionhandler;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.apache.log4j.Logger;
 import org.eclipse.glsp.api.action.Action;
+import org.eclipse.glsp.api.action.kind.ConfigureServerHandlersAction;
 import org.eclipse.glsp.api.action.kind.InitializeClientSessionAction;
+import org.eclipse.glsp.api.handler.ActionHandler;
+import org.eclipse.glsp.api.handler.OperationHandler;
 import org.eclipse.glsp.api.model.GraphicalModelState;
 import org.eclipse.glsp.api.protocol.ClientSessionManager;
 import org.eclipse.glsp.api.protocol.GLSPClient;
@@ -27,13 +39,25 @@ import org.eclipse.glsp.api.protocol.GLSPServerException;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
+/**
+ * Initializes the lifecycle for a ClientSession via the {@link ClientSessionManager},
+ * and notifies the client about all actions that this server can handle.
+ */
 public class InitializeClientSessionActionHandler extends BasicActionHandler<InitializeClientSessionAction> {
+
+   private static Logger LOG = Logger.getLogger(InitializeClientSessionActionHandler.class);
 
    @Inject
    protected ClientSessionManager clientSessionManager;
 
    @Inject
    protected Provider<GLSPClient> client;
+
+   @Inject
+   protected Provider<Set<ActionHandler>> serverActions;
+
+   @Inject
+   protected Provider<Set<OperationHandler>> serverOperations;
 
    @Override
    protected List<Action> executeAction(final InitializeClientSessionAction action,
@@ -45,7 +69,64 @@ public class InitializeClientSessionActionHandler extends BasicActionHandler<Ini
             "Could not create session for client id '%s'. Another session with the same id already exists",
             action.getClientId()));
       }
-      return none();
+
+      return listOf(configureServerHandlers());
+   }
+
+   private Action configureServerHandlers() {
+      Set<String> actions = serverActions.get().stream()
+         .flatMap(handler -> getActionKinds(handler).stream())
+         .filter(Objects::nonNull)
+         .collect(Collectors.toSet());
+      Set<String> operations = serverOperations.get().stream()
+         .map(this::getActionKind)
+         .filter(Objects::nonNull)
+         .collect(Collectors.toSet());
+
+      Set<String> allServerActions = Stream.concat(actions.stream(), operations.stream())
+         .collect(Collectors.toSet());
+
+      return new ConfigureServerHandlersAction(allServerActions);
+   }
+
+   protected Collection<String> getActionKinds(final ActionHandler actionHandler) {
+      if (actionHandler instanceof OperationActionHandler) {
+         // This is a special case, which delegates operations to operation handlers. As such,
+         // we can't determine its action kinds (But we'll retrieve all operation kinds in the next
+         // step anyway)
+         return Collections.emptyList();
+      }
+
+      List<String> actionKinds = actionHandler.getHandledActionTypes().stream().map(this::getActionKind)
+         .collect(Collectors.toList());
+      if (actionKinds.stream().anyMatch(Objects::isNull)) {
+         LOG.error("Unable to determine all action kinds for ActionHandler: " + actionHandler);
+      }
+      return actionKinds;
+   }
+
+   protected String getActionKind(final OperationHandler operationHandler) {
+      String actionKind = getActionKind(operationHandler.getHandledOperationType());
+      if (actionKind == null) {
+         LOG.error("Unable to determine action kind for OperationHandler: " + operationHandler);
+      }
+      return actionKind;
+   }
+
+   protected String getActionKind(final Class<? extends Action> actionClass) {
+      try {
+         Constructor<?> declaredConstructor = actionClass.getDeclaredConstructor();
+         Action a = actionClass.cast(declaredConstructor.newInstance());
+         return a.getKind();
+      } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | IllegalArgumentException
+         | InvocationTargetException ex) {
+         // Action doesn't have a valid 0-arg constructor, so we can't automatically determine the action kind.
+         // Extensions may need to override this method to handle this case.
+         LOG.error(
+            "Unable to determine the action kind for class " + actionClass + ". Manual declaration may be required.",
+            ex);
+         return null;
+      }
    }
 
 }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/DefaultGLSPModule.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/DefaultGLSPModule.java
@@ -42,6 +42,7 @@ import org.eclipse.glsp.api.registry.NavigationTargetProviderRegistry;
 import org.eclipse.glsp.api.registry.OperationHandlerRegistry;
 import org.eclipse.glsp.api.registry.ServerCommandHandlerRegistry;
 import org.eclipse.glsp.server.action.DefaultActionDispatcher;
+import org.eclipse.glsp.server.actionhandler.ClientActionHandler;
 import org.eclipse.glsp.server.factory.DefaultGraphGsonConfiguratorFactory;
 import org.eclipse.glsp.server.jsonrpc.DefaultClientSessionManager;
 import org.eclipse.glsp.server.jsonrpc.DefaultGLSPServer;
@@ -85,14 +86,23 @@ public abstract class DefaultGLSPModule extends GLSPModule {
 
    protected void configureServerCommandHandlers(final MultiBindConfig<ServerCommandHandler> bindings) {}
 
+   /**
+    * Actions that will be handled by delegating to the client, e.g. via {@link ClientActionHandler}
+    */
    protected void configureClientActions(final MultiBindConfig<Action> bindings) {
       bindings.addAll(MultiBindingDefaults.DEFAULT_CLIENT_ACTIONS);
    }
 
+   /**
+    * Actions that can be handled by the server.
+    */
    protected void configureActionHandlers(final MultiBindConfig<ActionHandler> bindings) {
       bindings.addAll(MultiBindingDefaults.DEFAULT_ACTION_HANDLERS);
    }
 
+   /***
+    * Operations that can be handled by the server.
+    */
    protected void configureOperationHandlers(
       final MultiBindConfig<OperationHandler> bindings) {
       bindings.addAll(MultiBindingDefaults.DEFAULT_OPERATION_HANDLERS);

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/MultiBindingDefaults.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/MultiBindingDefaults.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.eclipse.glsp.api.action.Action;
 import org.eclipse.glsp.api.action.kind.CenterAction;
 import org.eclipse.glsp.api.action.kind.ClearMarkersAction;
+import org.eclipse.glsp.api.action.kind.ConfigureServerHandlersAction;
 import org.eclipse.glsp.api.action.kind.ExportSVGAction;
 import org.eclipse.glsp.api.action.kind.FitToScreenAction;
 import org.eclipse.glsp.api.action.kind.GLSPServerStatusAction;
@@ -126,7 +127,8 @@ public final class MultiBindingDefaults {
       ServerStatusAction.class,
       TriggerNodeCreationAction.class,
       TriggerEdgeCreationAction.class,
-      UpdateModelAction.class);
+      UpdateModelAction.class,
+      ConfigureServerHandlersAction.class);
 
    public static final List<Class<? extends OperationHandler>> DEFAULT_OPERATION_HANDLERS = Lists.newArrayList(
       ApplyLabelEditOperationHandler.class,


### PR DESCRIPTION
When receiving an InitializeClientSessionAction, the server now sends a ConfigureServerHandlersAction which contains the list of actionKinds that the server can handle.

The client can use this to dynamically configure server-handled actions, rather than listing them explicitly.