### PR TITLE
#140 Improve extendibility of DefaultGLSPServer

### DIFF
--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/internal/di/MultiBindingDefaults.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/internal/di/MultiBindingDefaults.java
@@ -24,6 +24,7 @@ import org.eclipse.glsp.server.actions.ClientActionHandler;
 import org.eclipse.glsp.server.actions.ComputedBoundsActionHandler;
 import org.eclipse.glsp.server.actions.ConfigureServerHandlersAction;
 import org.eclipse.glsp.server.actions.DisposeClientSessionActionHandler;
+import org.eclipse.glsp.server.actions.ExportSVGAction;
 import org.eclipse.glsp.server.actions.FitToScreenAction;
 import org.eclipse.glsp.server.actions.GLSPServerStatusAction;
 import org.eclipse.glsp.server.actions.InitializeClientSessionActionHandler;
@@ -101,6 +102,7 @@ public final class MultiBindingDefaults {
 
    public static final List<Class<? extends Action>> DEFAULT_CLIENT_ACTIONS = Lists.newArrayList(
       CenterAction.class,
+      ExportSVGAction.class,
       DeleteMarkersAction.class,
       FitToScreenAction.class,
       GLSPServerStatusAction.class,

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/jsonrpc/DefaultGLSPServer.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/jsonrpc/DefaultGLSPServer.java
@@ -44,11 +44,11 @@ public class DefaultGLSPServer<T> implements GLSPJsonrpcServer {
    @Inject
    protected ActionDispatcher actionDispatcher;
 
-   private GLSPJsonrpcClient clientProxy;
-   private final Class<T> optionsClazz;
+   protected GLSPJsonrpcClient clientProxy;
+   protected final Class<T> optionsClazz;
    protected CompletableFuture<Boolean> initialized;
 
-   private String applicationId;
+   protected String applicationId;
 
    public DefaultGLSPServer() {
       this(null);


### PR DESCRIPTION
Avoid private members in the default implementation for easier customization in  subclasses.

Follow-up for eclipse-glsp/client/issues/140