### PR TITLE
#35 Extend server launcher for embedded use case

### DIFF
--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/launch/DefaultGLSPServerLauncher.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/launch/DefaultGLSPServerLauncher.java
@@ -44,6 +44,7 @@ import com.google.gson.GsonBuilder;
 import com.google.inject.Injector;
 
 public class DefaultGLSPServerLauncher extends GLSPServerLauncher {
+   public static final String START_UP_COMPLETE_MSG = "[GLSP-Server]:Startup completed";
    private static Logger log = Logger.getLogger(DefaultGLSPServerLauncher.class);
 
    private ExecutorService threadPool;
@@ -73,7 +74,7 @@ public class DefaultGLSPServerLauncher extends GLSPServerLauncher {
       serverSocket = AsynchronousServerSocketChannel.open().bind(new InetSocketAddress(hostname, port));
       threadPool = Executors.newCachedThreadPool();
 
-      CompletionHandler<AsynchronousSocketChannel, Void> handler = new CompletionHandler<AsynchronousSocketChannel, Void>() {
+      CompletionHandler<AsynchronousSocketChannel, Void> handler = new CompletionHandler<>() {
          @Override
          public void completed(final AsynchronousSocketChannel result, final Void attachment) {
             serverSocket.accept(null, this); // Prepare for the next connection
@@ -88,6 +89,9 @@ public class DefaultGLSPServerLauncher extends GLSPServerLauncher {
 
       serverSocket.accept(null, handler);
       log.info("The GLSP server is ready to accept new client requests on port: " + port);
+      // Print a message to the output stream that indicates that the start is completed.
+      // This indicates to the client that the sever process is ready (in an embedded scenario).
+      System.out.println(START_UP_COMPLETE_MSG);
 
       return onShutdown;
    }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/utils/FutureUtil.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/utils/FutureUtil.java
@@ -21,7 +21,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
-public class FutureUtil {
+public final class FutureUtil {
+
+   private FutureUtil() {}
 
    /**
     * <p>
@@ -42,6 +44,7 @@ public class FutureUtil {
     *         A single {@link CompletableFuture}, that will be completed once all of the actions are complete.
     *         The future will be completed exceptionally if any of the actions completes exceptionally.
     */
+   @SuppressWarnings("checkstyle:cyclomaticComplexity")
    public static CompletableFuture<Void> aggregateResults(final Collection<CompletableFuture<Void>> actions) {
       if (actions.isEmpty()) {
          return CompletableFuture.completedFuture(null);


### PR DESCRIPTION
Extend the `DefaultGLSPServerLauncher` to print a message to the output stream once the startup is completed and the server is ready to accept client requests.
This is needed for usecases where the client launches the server itself, in an embedded process. This way the client process can wait for the startup success message from the server before trying to connect to it.

Also: Fix checkstyle warings in 'FutureUtil'

Part of eclipse-glsp/glsp/issues/35