### PR TITLE
149: [Websocket] Do not reuse the same Injector for each client connection

### DIFF
--- a/plugins/org.eclipse.glsp.server.websocket/src/org/eclipse/glsp/server/websocket/GLSPConfigurator.java
+++ b/plugins/org.eclipse.glsp.server.websocket/src/org/eclipse/glsp/server/websocket/GLSPConfigurator.java
@@ -17,6 +17,7 @@ package org.eclipse.glsp.server.websocket;
 
 import java.util.List;
 import java.util.ServiceLoader;
+import java.util.function.Supplier;
 
 import javax.websocket.Extension;
 import javax.websocket.HandshakeResponse;
@@ -30,9 +31,9 @@ import com.google.inject.Injector;
 
 public class GLSPConfigurator extends Configurator {
    private Configurator containerConfigurator;
-   private final Injector injector;
+   private final Supplier<Injector> injector;
 
-   public GLSPConfigurator(final Injector injector) {
+   public GLSPConfigurator(final Supplier<Injector> injector) {
       this.injector = injector;
    }
 
@@ -66,6 +67,8 @@ public class GLSPConfigurator extends Configurator {
 
    @Override
    public <T> T getEndpointInstance(final Class<T> endpointClass) throws InstantiationException {
+      // This is invoked on each new client connection; so we need a new Injector instance.
+      Injector injector = this.injector.get();
       return injector.getInstance(endpointClass);
    }
 

--- a/plugins/org.eclipse.glsp.server.websocket/src/org/eclipse/glsp/server/websocket/WebsocketServerLauncher.java
+++ b/plugins/org.eclipse.glsp.server.websocket/src/org/eclipse/glsp/server/websocket/WebsocketServerLauncher.java
@@ -74,7 +74,7 @@ public class WebsocketServerLauncher extends GLSPServerLauncher {
          ServerContainer container = WebSocketServerContainerInitializer.configureContext(webAppContext);
          ServerEndpointConfig.Builder builder = ServerEndpointConfig.Builder.create(GLSPServerEndpoint.class,
             "/" + endpointPath);
-         builder.configurator(new GLSPConfigurator(createInjector()));
+         builder.configurator(new GLSPConfigurator(this::createInjector));
          container.addEndpoint(builder.build());
 
          // Start the server


### PR DESCRIPTION
- Create a new Injector instance for each client connection, as expected by the GLSP Server infra

fixes eclipse-glsp/glsp/issues/149