### PR TITLE
#153: Improve external navigation support through dedicated action

### DIFF
--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/features/navigation/NavigateToExternalTargetAction.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/features/navigation/NavigateToExternalTargetAction.java
@@ -17,24 +17,22 @@ package org.eclipse.glsp.server.features.navigation;
 
 import org.eclipse.glsp.server.actions.Action;
 
-public class NavigateToTargetAction extends Action {
+public class NavigateToExternalTargetAction extends Action {
 
-   public static final String ID = "navigateToTarget";
+   public static final String ID = "navigateToExternalTarget";
 
    private NavigationTarget target;
 
-   public NavigateToTargetAction() {
+   public NavigateToExternalTargetAction() {
       super(ID);
    }
 
-   public NavigateToTargetAction(final NavigationTarget target) {
+   public NavigateToExternalTargetAction(final NavigationTarget target) {
       this();
       this.target = target;
    }
 
    public NavigationTarget getTarget() { return target; }
 
-   public void setTarget(final NavigationTarget navigationTarget) {
-      this.target = navigationTarget;
-   }
+   public void setTarget(final NavigationTarget navigationTarget) { this.target = navigationTarget; }
 }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/internal/di/MultiBindingDefaults.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/internal/di/MultiBindingDefaults.java
@@ -53,6 +53,7 @@ import org.eclipse.glsp.server.features.directediting.ApplyLabelEditOperationHan
 import org.eclipse.glsp.server.features.directediting.RequestEditValidationHandler;
 import org.eclipse.glsp.server.features.directediting.SetEditValidationResultAction;
 import org.eclipse.glsp.server.features.modelsourcewatcher.ModelSourceChangedAction;
+import org.eclipse.glsp.server.features.navigation.NavigateToExternalTargetAction;
 import org.eclipse.glsp.server.features.navigation.NavigateToTargetAction;
 import org.eclipse.glsp.server.features.navigation.RequestNavigationTargetsActionHandler;
 import org.eclipse.glsp.server.features.navigation.ResolveNavigationTargetActionHandler;
@@ -108,6 +109,7 @@ public final class MultiBindingDefaults {
       GLSPServerStatusAction.class,
       ModelSourceChangedAction.class,
       NavigateToTargetAction.class,
+      NavigateToExternalTargetAction.class,
       RequestBoundsAction.class,
       SelectAction.class,
       SelectAllAction.class,


### PR DESCRIPTION
- Introduce dedicated 'NavigateToExternalTarget' action
- Fix issue with wrong field name in 'NavigateToTarget' action

Part of eclipse-glsp/glsp/issues/153

Signed-off-by: Martin Fleck <mfleck@eclipsesource.com>