### PR TITLE
#156 Use package-import rather than require-bundle for javax.servlet

### DIFF
--- a/plugins/org.eclipse.glsp.server.websocket/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.server.websocket/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-Vendor: Eclipse GLSP
 Automatic-Module-Name: com.eclipsesource.glps.server.websocket
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: javax.websocket;bundle-version="1.0.0";visibility:=reexport,
- javax.servlet;bundle-version="3.1.0";visibility:=reexport,
  org.eclipse.jetty.server;bundle-version="9.4.14";visibility:=reexport,
  org.eclipse.jetty.servlet;bundle-version="9.4.14";visibility:=reexport,
  org.eclipse.jetty.util;bundle-version="9.4.14";visibility:=reexport,
@@ -21,3 +20,4 @@ Require-Bundle: javax.websocket;bundle-version="1.0.0";visibility:=reexport,
  org.eclipse.lsp4j,
  org.eclipse.lsp4j.jsonrpc
 Export-Package: org.eclipse.glsp.server.websocket
+Import-Package: javax.servlet;version="[3.1.0,4.0.0)"


### PR DESCRIPTION
- Multiple bundles may provide javax.servlet packages, which can result in some conflicts at runtime. Using a strict package-import, with the same dependency range as Jetty, seems more reliable.