### PR TITLE
#197 #196 Improve dirty state handling

### DIFF
--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/SaveModelActionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/SaveModelActionHandler.java
@@ -51,7 +51,7 @@ public class SaveModelActionHandler extends BasicActionHandler<SaveModelAction> 
       } finally {
          modelSourceWatcher.continueWatching(modelState);
       }
-      return listOf(new SetDirtyStateAction(modelState.isDirty(), action));
+      return listOf(new SetDirtyStateAction(modelState.isDirty(), SetDirtyStateAction.Reason.SAVE));
    }
 
    protected void saveModelState(final GModelState modelState) {

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/SaveModelActionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/SaveModelActionHandler.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019 EclipseSource and others.
+ * Copyright (c) 2019-2021 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -51,7 +51,7 @@ public class SaveModelActionHandler extends BasicActionHandler<SaveModelAction> 
       } finally {
          modelSourceWatcher.continueWatching(modelState);
       }
-      return listOf(new SetDirtyStateAction(modelState.isDirty()));
+      return listOf(new SetDirtyStateAction(modelState.isDirty(), action));
    }
 
    protected void saveModelState(final GModelState modelState) {

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/SetDirtyStateAction.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/SetDirtyStateAction.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020 EclipseSource and others.
+ * Copyright (c) 2020-2021 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -20,18 +20,24 @@ public class SetDirtyStateAction extends Action {
    public static final String ID = "setDirtyState";
 
    private boolean isDirty;
+   private Action causedBy;
 
    public SetDirtyStateAction() {
       super(ID);
    }
 
-   public SetDirtyStateAction(final boolean isDirty) {
+   public SetDirtyStateAction(final boolean isDirty, final Action causedBy) {
       this();
       this.isDirty = isDirty;
+      this.causedBy = causedBy;
    }
 
    public boolean isDirty() { return isDirty; }
 
    public void setDirty(final boolean isDirty) { this.isDirty = isDirty; }
+
+   public Action getCausedBy() { return causedBy; }
+
+   public void setCausedBy(final Action causedBy) { this.causedBy = causedBy; }
 
 }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/SetDirtyStateAction.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/SetDirtyStateAction.java
@@ -16,28 +16,39 @@
 package org.eclipse.glsp.server.actions;
 
 public class SetDirtyStateAction extends Action {
-
    public static final String ID = "setDirtyState";
 
    private boolean isDirty;
-   private Action causedBy;
+   private String reason;
 
    public SetDirtyStateAction() {
       super(ID);
    }
 
-   public SetDirtyStateAction(final boolean isDirty, final Action causedBy) {
+   public SetDirtyStateAction(final boolean isDirty) {
       this();
       this.isDirty = isDirty;
-      this.causedBy = causedBy;
+   }
+
+   public SetDirtyStateAction(final boolean isDirty, final String reason) {
+      this(isDirty);
+      this.reason = reason;
    }
 
    public boolean isDirty() { return isDirty; }
 
    public void setDirty(final boolean isDirty) { this.isDirty = isDirty; }
 
-   public Action getCausedBy() { return causedBy; }
+   public String getReason() { return reason; }
 
-   public void setCausedBy(final Action causedBy) { this.causedBy = causedBy; }
+   public void setReason(final String reason) { this.reason = reason; }
+
+   public static class Reason {
+      public static final String OPERATION = "operation";
+      public static final String UNDO = "undo";
+      public static final String REDO = "redo";
+      public static final String SAVE = "save";
+      public static final String EXTERNAL = "external";
+   }
 
 }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/diagram/DiagramConfiguration.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/diagram/DiagramConfiguration.java
@@ -48,4 +48,8 @@ public interface DiagramConfiguration {
    default boolean needsClientLayout() {
       return true;
    }
+
+   default boolean animatedUpdate() {
+      return true;
+   }
 }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/features/core/model/ModelSubmissionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/features/core/model/ModelSubmissionHandler.java
@@ -56,7 +56,7 @@ public class ModelSubmissionHandler {
     * </p>
     *
     * @param modelState The model state to submit.
-    * @param reason     The action/operation that caused the model update
+    * @param reason     The optional reason that caused the model update.
     * @return A list of actions to be processed in order to submit the model.
     */
    public List<Action> submitModel(final GModelState modelState, final String reason) {

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/features/core/model/RequestModelActionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/features/core/model/RequestModelActionHandler.java
@@ -51,7 +51,7 @@ public class RequestModelActionHandler extends BasicActionHandler<RequestModelAc
 
       modelSourceWatcher.startWatching(modelState);
 
-      return modelSubmissionHandler.submitModel(modelState, action);
+      return modelSubmissionHandler.submitModel(modelState);
    }
 
    protected void notifyStartLoading(final GModelState modelState) {

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/features/core/model/RequestModelActionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/features/core/model/RequestModelActionHandler.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019 EclipseSource and others.
+ * Copyright (c) 2019-2021 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -51,7 +51,7 @@ public class RequestModelActionHandler extends BasicActionHandler<RequestModelAc
 
       modelSourceWatcher.startWatching(modelState);
 
-      return modelSubmissionHandler.submitModel(modelState);
+      return modelSubmissionHandler.submitModel(modelState, action);
    }
 
    protected void notifyStartLoading(final GModelState modelState) {

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/features/undoredo/UndoRedoActionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/features/undoredo/UndoRedoActionHandler.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.apache.log4j.Logger;
 import org.eclipse.glsp.server.actions.Action;
 import org.eclipse.glsp.server.actions.ActionHandler;
+import org.eclipse.glsp.server.actions.SetDirtyStateAction;
 import org.eclipse.glsp.server.features.core.model.ModelSubmissionHandler;
 import org.eclipse.glsp.server.model.GModelState;
 
@@ -36,10 +37,10 @@ public class UndoRedoActionHandler implements ActionHandler {
    public List<Action> execute(final Action action, final GModelState modelState) {
       if (action instanceof UndoAction && modelState.canUndo()) {
          modelState.undo();
-         return modelSubmissionHandler.submitModel(modelState, action);
+         return modelSubmissionHandler.submitModel(modelState, SetDirtyStateAction.Reason.UNDO);
       } else if (action instanceof RedoAction && modelState.canRedo()) {
          modelState.redo();
-         return modelSubmissionHandler.submitModel(modelState, action);
+         return modelSubmissionHandler.submitModel(modelState, SetDirtyStateAction.Reason.REDO);
       }
       LOG.warn("Cannot undo or redo");
       return none();

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/features/undoredo/UndoRedoActionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/features/undoredo/UndoRedoActionHandler.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019 EclipseSource and others.
+ * Copyright (c) 2019-2021 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -36,10 +36,10 @@ public class UndoRedoActionHandler implements ActionHandler {
    public List<Action> execute(final Action action, final GModelState modelState) {
       if (action instanceof UndoAction && modelState.canUndo()) {
          modelState.undo();
-         return modelSubmissionHandler.submitModel(modelState);
+         return modelSubmissionHandler.submitModel(modelState, action);
       } else if (action instanceof RedoAction && modelState.canRedo()) {
          modelState.redo();
-         return modelSubmissionHandler.submitModel(modelState);
+         return modelSubmissionHandler.submitModel(modelState, action);
       }
       LOG.warn("Cannot undo or redo");
       return none();

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operations/OperationActionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operations/OperationActionHandler.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 
 import org.eclipse.glsp.server.actions.Action;
 import org.eclipse.glsp.server.actions.BasicActionHandler;
+import org.eclipse.glsp.server.actions.SetDirtyStateAction;
 import org.eclipse.glsp.server.features.core.model.ModelSubmissionHandler;
 import org.eclipse.glsp.server.internal.gmodel.commandstack.GModelRecordingCommand;
 import org.eclipse.glsp.server.model.GModelState;
@@ -57,7 +58,7 @@ public class OperationActionHandler extends BasicActionHandler<Operation> {
       GModelRecordingCommand command = new GModelRecordingCommand(modelState.getRoot(), handler.getLabel(),
          () -> handler.execute(operation, modelState));
       modelState.execute(command);
-      return modelSubmissionHandler.submitModel(modelState, operation);
+      return modelSubmissionHandler.submitModel(modelState, SetDirtyStateAction.Reason.OPERATION);
    }
 
    public static Optional<? extends OperationHandler> getOperationHandler(final Operation operation,

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operations/OperationActionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operations/OperationActionHandler.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019 EclipseSource and others.
+ * Copyright (c) 2019-2021 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -57,7 +57,7 @@ public class OperationActionHandler extends BasicActionHandler<Operation> {
       GModelRecordingCommand command = new GModelRecordingCommand(modelState.getRoot(), handler.getLabel(),
          () -> handler.execute(operation, modelState));
       modelState.execute(command);
-      return modelSubmissionHandler.submitModel(modelState);
+      return modelSubmissionHandler.submitModel(modelState, operation);
    }
 
    public static Optional<? extends OperationHandler> getOperationHandler(final Operation operation,


### PR DESCRIPTION
The `SetDirtyStateAction` now also declares the action/operation which caused the dirty state change. 
Ensure that the `SetDirtyStateAction` is only sent once during a model update
Ensure that layout engine is invoked after bounds have been computed (AutomaticServerLayout case)

Part of https://github.com/eclipse-glsp/glsp/issues/197
Fixes https://github.com/eclipse-glsp/glsp/issues/196