### PR TITLE
#208 Add `fileUri` to `SaveModelAction`

### DIFF
--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/SaveModelAction.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/SaveModelAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 EclipseSource and others.
+ * Copyright (c) 2019-2021 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,12 +15,23 @@
  ******************************************************************************/
 package org.eclipse.glsp.server.actions;
 
+import java.util.Optional;
+
 public class SaveModelAction extends Action {
 
    public static final String ID = "saveModel";
+   private String fileUri;
 
    public SaveModelAction() {
       super(ID);
    }
 
+   public SaveModelAction(final String fileUri) {
+      this();
+      this.fileUri = fileUri;
+   }
+
+   public void setFileUri(final String fileUri) { this.fileUri = fileUri; }
+
+   public Optional<String> getFileUri() { return Optional.ofNullable(fileUri); }
 }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/utils/ClientOptions.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/utils/ClientOptions.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019 EclipseSource and others.
+ * Copyright (c) 2019-2021 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -51,7 +51,14 @@ public final class ClientOptions {
    }
 
    public static Optional<File> getSourceUriAsFile(final Map<String, String> options) {
-      final Optional<String> uriString = getValue(options, SOURCE_URI);
-      return uriString.map(uri -> uri.replace(FILE_PREFIX, "")).map(path -> new File(path));
+      return getValue(options, SOURCE_URI).map(ClientOptions::getAsFile);
+   }
+
+   public static String adaptUri(final String uri) {
+      return uri.replace(FILE_PREFIX, "");
+   }
+
+   public static File getAsFile(final String uri) {
+      return new File(adaptUri(uri));
    }
 }


### PR DESCRIPTION
Also update `SaveModelActionHandler` to process the new property accordingly.
If a fileUri has been passed that is not equal to the sourceURi, the handler will save the current modelstate to the new fileUri but keeps the current dirty state
Part of eclipse-glsp/glsp/issues/208