### PR TITLE
#60 #17 Cleanup/update CI & maven build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
         stage ('Build: Plain Maven (M2)') {
             steps {
                 timeout(30){
-                     sh "mvn clean verify -Pm2 --batch-mode package"    
+                     sh "mvn clean verify -Pm2 -B"  
                 }
             }
         }
@@ -16,7 +16,7 @@ pipeline {
         stage ('Build: Eclipse-based (P2)') {
             steps {
                 timeout(30){
-                    sh "mvn clean verify -Pp2 --batch-mode package"    
+                    sh "mvn clean verify -Pp2 -B"    
                 }
             }
         }
@@ -39,6 +39,9 @@ pipeline {
     post {
         always {
                 junit 'tests/**/surefire-reports/*.xml'
+
+                // Record checkstyle
+                recordIssues  publishAllIssues: true,tool: checkStyle(reportEncoding: 'UTF-8'), qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]]
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,8 +40,12 @@ pipeline {
         always {
                 junit 'tests/**/surefire-reports/*.xml'
 
-                // Record checkstyle
+                // Record & publish checkstyle issues
                 recordIssues  publishAllIssues: true,tool: checkStyle(reportEncoding: 'UTF-8'), qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]]
+
+                withChecks('My Custom Checks Name') {
+                recordIssues tool: java(pattern: '*.log')
+                }
         }
     }
 }

--- a/examples/org.eclipse.glsp.example.workflow/pom.xml
+++ b/examples/org.eclipse.glsp.example.workflow/pom.xml
@@ -41,6 +41,12 @@
 			<organization>EclipseSource</organization>
 			<organizationUrl>http://www.eclipsesource.com</organizationUrl>
 		</developer>
+		<developer>
+			<name>Camille Letavernier</name>
+			<email>cletavernier@eclipsesource.com</email>
+			<organization>EclipseSource</organization>
+			<organizationUrl>http://www.eclipsesource.com</organizationUrl>
+		</developer>
 	</developers>
 
 	<scm>
@@ -53,7 +59,7 @@
 	<properties>
 		<package-type>eclipse-plugin</package-type>
 	</properties>
-	
+
 	<dependencies>
 		<dependency>
 			<groupId>com.google.inject</groupId>
@@ -81,7 +87,7 @@
 			<version>0.5.0</version>
 		</dependency>
 	</dependencies>
-	
+
 	<profiles>
 		<profile>
 			<id>m2</id>
@@ -93,25 +99,6 @@
 			</properties>
 			<build>
 				<plugins>
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>build-helper-maven-plugin</artifactId>
-						<version>1.7</version>
-						<executions>
-							<execution>
-								<id>add-source</id>
-								<phase>generate-sources</phase>
-								<goals>
-									<goal>add-source</goal>
-								</goals>
-								<configuration>
-									<sources>
-										<source>src-gen</source>
-									</sources>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-deploy-plugin</artifactId>
@@ -132,48 +119,8 @@
 				<plugins>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-dependency-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>copy-dependencies</id>
-								<phase>package</phase>
-								<goals>
-									<goal>copy-dependencies</goal>
-								</goals>
-								<configuration>
-									<outputDirectory>${project.build.directory}/libs</outputDirectory>
-									<overWriteReleases>false</overWriteReleases>
-									<overWriteSnapshots>false</overWriteSnapshots>
-									<overWriteIfNewer>true</overWriteIfNewer>
-									<excludeTransitive>false</excludeTransitive>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>com.googlecode.addjars-maven-plugin</groupId>
-						<artifactId>addjars-maven-plugin</artifactId>
-						<version>1.0.5</version>
-						<executions>
-							<execution>
-								<phase>package</phase>
-								<goals>
-									<goal>add-jars</goal>
-								</goals>
-								<configuration>
-									<resources>
-										<resource>
-											<directory>${project.build.directory}/libs</directory>
-										</resource>
-									</resources>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-shade-plugin</artifactId>
-						<version>3.0.0</version>
+						<version>3.2.4</version>
 						<configuration>
 							<transformers>
 								<transformer
@@ -181,14 +128,21 @@
 									<mainClass>org.eclipse.glsp.example.workflow.launch.WorkflowServerLauncher</mainClass>
 								</transformer>
 							</transformers>
+							<artifactSet>
+								<excludes>
+									<exclude>javax.websocket:javax.websocket-client-api</exclude>
+								</excludes>
+							</artifactSet>
 							<filters>
 								<filter>
 									<artifact>*:*</artifact>
 									<excludes>
-										<exclude>META-INF/INDEX.LIST</exclude>
-										<exclude>META-INF/*.SF</exclude>
-										<exclude>META-INF/*.DSA</exclude>
-										<exclude>META-INF/*.RSA</exclude>
+										<exclude>META-INF/MANIFEST.MF</exclude>
+										<exclude>META-INF/DEPENDENCIES</exclude>
+										<exclude>META-INF/ECLIPSE_*</exclude>
+										<exclude>META-INF/LICENSE*</exclude>
+										<exclude>META-INF/services/javax.servlet.ServletContainerInitializer*</exclude>
+										<exclude>META-INF/NOTICE*</exclude>
 										<exclude>.options</exclude>
 										<exclude>.api_description</exclude>
 										<exclude>*.profile</exclude>
@@ -199,6 +153,8 @@
 										<exclude>modeling32.png</exclude>
 										<exclude>systembundle.properties</exclude>
 										<exclude>profile.list</exclude>
+										<exclude>module-info.class</exclude>
+										<exclude>plugin.properties</exclude>
 										<exclude>**/*._trace</exclude>
 										<exclude>**/*.g</exclude>
 										<exclude>**/*.tokens</exclude>

--- a/plugins/org.eclipse.glsp.graph/pom.xml
+++ b/plugins/org.eclipse.glsp.graph/pom.xml
@@ -40,6 +40,12 @@
 			<organization>EclipseSource</organization>
 			<organizationUrl>http://www.eclipsesource.com</organizationUrl>
 		</developer>
+		<developer>
+			<name>Camille Letavernier</name>
+			<email>cletavernier@eclipsesource.com</email>
+			<organization>EclipseSource</organization>
+			<organizationUrl>http://www.eclipsesource.com</organizationUrl>
+		</developer>
 	</developers>
 
 	<scm>
@@ -88,25 +94,6 @@
 
 			<build>
 				<plugins>
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>build-helper-maven-plugin</artifactId>
-						<version>1.7</version>
-						<executions>
-							<execution>
-								<id>add-source</id>
-								<phase>generate-sources</phase>
-								<goals>
-									<goal>add-source</goal>
-								</goals>
-								<configuration>
-									<sources>
-										<source>src-gen</source>
-									</sources>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-deploy-plugin</artifactId>

--- a/plugins/org.eclipse.glsp.layout/pom.xml
+++ b/plugins/org.eclipse.glsp.layout/pom.xml
@@ -40,6 +40,12 @@
 			<organization>EclipseSource</organization>
 			<organizationUrl>http://www.eclipsesource.com</organizationUrl>
 		</developer>
+		<developer>
+			<name>Camille Letavernier</name>
+			<email>cletavernier@eclipsesource.com</email>
+			<organization>EclipseSource</organization>
+			<organizationUrl>http://www.eclipsesource.com</organizationUrl>
+		</developer>
 	</developers>
 
 	<scm>

--- a/plugins/org.eclipse.glsp.server.websocket/pom.xml
+++ b/plugins/org.eclipse.glsp.server.websocket/pom.xml
@@ -40,6 +40,12 @@
 			<organization>EclipseSource</organization>
 			<organizationUrl>http://www.eclipsesource.com</organizationUrl>
 		</developer>
+		<developer>
+			<name>Camille Letavernier</name>
+			<email>cletavernier@eclipsesource.com</email>
+			<organization>EclipseSource</organization>
+			<organizationUrl>http://www.eclipsesource.com</organizationUrl>
+		</developer>
 	</developers>
 
 	<scm>

--- a/plugins/org.eclipse.glsp.server.websocket/src/org/eclipse/glsp/server/websocket/GLSPConfigurator.java
+++ b/plugins/org.eclipse.glsp.server.websocket/src/org/eclipse/glsp/server/websocket/GLSPConfigurator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 EclipseSource and others.
+ * Copy234right (c) 2019 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/plugins/org.eclipse.glsp.server/pom.xml
+++ b/plugins/org.eclipse.glsp.server/pom.xml
@@ -40,6 +40,12 @@
 			<organization>EclipseSource</organization>
 			<organizationUrl>http://www.eclipsesource.com</organizationUrl>
 		</developer>
+		<developer>
+			<name>Camille Letavernier</name>
+			<email>cletavernier@eclipsesource.com</email>
+			<organization>EclipseSource</organization>
+			<organizationUrl>http://www.eclipsesource.com</organizationUrl>
+		</developer>
 	</developers>
 
 	<scm>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,12 @@
 			<organization>EclipseSource</organization>
 			<organizationUrl>http://www.eclipsesource.com</organizationUrl>
 		</developer>
+		<developer>
+			<name>Camille Letavernier</name>
+			<email>cletavernier@eclipsesource.com</email>
+			<organization>EclipseSource</organization>
+			<organizationUrl>http://www.eclipsesource.com</organizationUrl>
+		</developer>
 	</developers>
 
 	<scm>
@@ -53,7 +59,6 @@
 		<java.source>11</java.source>
 		<java.target>11</java.target>
 		<project.build.java.target>11</project.build.java.target>
-		<target.version>0.9.0-SNAPSHOT</target.version>
 	</properties>
 
 	<build>
@@ -65,6 +70,7 @@
 				<configuration>
 					<source>${java.source}</source>
 					<target>${java.target}</target>
+					<generatedSourcesDirectory>src-gen</generatedSourcesDirectory>
 				</configuration>
 			</plugin>
 		</plugins>
@@ -91,10 +97,9 @@
 			</activation>
 
 			<properties>
-				<tycho-version>2.2.0</tycho-version>
-				<tychoExtrasVersion>2.2.0</tychoExtrasVersion>
+				<tycho-version>2.3.0</tycho-version>
 				<maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
-
+				<target.version>0.9.0-SNAPSHOT</target.version>
 			</properties>
 
 			<modules>
@@ -229,13 +234,10 @@
 				<activeByDefault>false</activeByDefault>
 			</activation>
 
-			<repositories>
-				<repository>
-					<id>sonatype</id>
-					<name>Sonatype</name>
-					<url>https://oss.sonatype.org/content/groups/public</url>
-				</repository>
-			</repositories>
+			<properties>
+				<checkstyle.plugin>3.1.2</checkstyle.plugin>
+				<checkstyle>8.39</checkstyle>
+			</properties>
 
 			<modules>
 				<module>plugins/org.eclipse.glsp.graph</module>
@@ -287,23 +289,22 @@
 							</argLine>
 						</configuration>
 					</plugin>
-
 					<!-- to disable use -Dcheckstyle.skip -->
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-checkstyle-plugin</artifactId>
-						<version>3.1.0</version>
+						<version>${checkstyle.plugin}</version>
 						<configuration>
 							<configLocation>emfcloud-checkstyle.xml</configLocation>
 							<consoleOutput>true</consoleOutput>
-							<sourceDirectories>src</sourceDirectories>
+							<excludes>**/src-gen/**/*.java</excludes>
 						</configuration>
 						<executions>
 							<execution>
+								<phase>validate</phase>
 								<goals>
 									<goal>check</goal>
 								</goals>
-								<phase>verify</phase>
 							</execution>
 						</executions>
 						<dependencies>
@@ -315,7 +316,7 @@
 							<dependency>
 								<groupId>com.puppycrawl.tools</groupId>
 								<artifactId>checkstyle</artifactId>
-								<version>8.29</version>
+								<version>${checkstyle}</version>
 							</dependency>
 						</dependencies>
 					</plugin>

--- a/releng/org.eclipse.glsp.repository/pom.xml
+++ b/releng/org.eclipse.glsp.repository/pom.xml
@@ -13,6 +13,14 @@
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-publisher-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<profiles>JavaSE-11</profiles>
+				</configuration>
+			</plugin>
 			<!-- Skip cleaning of this module otherwise the release build is not working 
 				on the jenkins instance -->
 			<plugin>
@@ -24,7 +32,7 @@
 			</plugin>
 		</plugins>
 	</build>
-	
+
 	<profiles>
 		<profile>
 			<id>p2-release</id>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -41,22 +41,22 @@
 							<version>${tycho-version}</version>
 						</plugin>
 						<plugin>
-							<groupId>org.eclipse.tycho.extras</groupId>
-							<artifactId>tycho-source-feature-plugin</artifactId>
-							<version>${tychoExtrasVersion}</version>
+							<groupId>org.eclipse.tycho</groupId>
+							<artifactId>tycho-source-plugin</artifactId>
+							<version>${tycho-version}</version>
 						</plugin>
 					</plugins>
 				</pluginManagement>
 				<plugins>
 					<plugin>
-						<groupId>org.eclipse.tycho.extras</groupId>
-						<artifactId>tycho-source-feature-plugin</artifactId>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-source-plugin</artifactId>
 						<executions>
 							<execution>
-								<id>source-feature</id>
+								<id>feature-source</id>
 								<phase>package</phase>
 								<goals>
-									<goal>source-feature</goal>
+									<goal>feature-source</goal>
 								</goals>
 								<configuration>
 									<excludes>


### PR DESCRIPTION
Jenkinsfile:
- Replace `--batch-mode´ with shorthand notation and remove unnecessary `package` argument
- Enable checkstyle reporting for m2 build

Maven build
- Update metdata
- Update to tycho 2.3.0
- Define src-gen directory in maven-compiler-plugin instead of using the additional builder-helper-maven-plugin
- Replace deprecated typcho-source-feature-plugin
- Improve fatjar profile to fix build warnings regarding overlapping classes.

Part of eclipse-glsp/glsp/issues/60
Part of eclipse-glsp/glsp/issues/17