### PR TITLE
#60 #17 Cleanup/update CI & maven build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,29 +1,61 @@
-pipeline { 
-    agent any  
-    tools { 
+pipeline {
+    agent any
+    tools {
         maven 'apache-maven-latest'
         jdk 'openjdk-jdk11-latest'
     }
     stages {
+        
+
         stage ('Build: Plain Maven (M2)') {
             steps {
-                timeout(30){
-                     sh "mvn clean verify -Pm2 --batch-mode package"    
+                // Not fail build on stage failure => always execute next stage
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                    timeout(30) {
+                        sh 'mvn clean verify -Pm2 -B -Dcheckstyle.skip -DskipTests'
+                    }
+                }
+            }
+        }
+
+        stage('Checkstyle') {
+            steps {
+                timeout(30) {
+                     sh ' mvn checkstyle:check -Pm2 -B'
+                }
+            }
+
+            post{
+                always{
+                    // Record & publish checkstyle issues
+                    recordIssues  enabledForFailure: true, publishAllIssues: true,
+                    tool: checkStyle(reportEncoding: 'UTF-8'),
+                    qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]]
+                }
+            }
+        } 
+
+        stage('Tests') {
+            steps {
+                timeout(30) {
+                    sh 'mvn test -Pm2 -B'
                 }
             }
         }
 
         stage ('Build: Eclipse-based (P2)') {
             steps {
-                timeout(30){
-                    sh "mvn clean verify -Pp2 --batch-mode package"    
+                timeout(30) {
+                    sh 'mvn clean verify -Pp2 -B'
                 }
             }
         }
 
-        stage ('Deploy)') {
-            when { branch 'master'}
-             steps {
+
+
+        stage ('Deploy (master only)') {
+            when { branch 'master' }
+            steps {
                 parallel(
                     p2: {
                         build job: 'deploy-p2-glsp-server', wait: false
@@ -32,13 +64,18 @@ pipeline {
                         build job: 'deploy-m2-glsp-server', wait: false
                     }
                 )
-             }
+            }
         }
     }
 
     post {
         always {
+            // Record & publish test results
+            withChecks('Tests') {
                 junit 'tests/**/surefire-reports/*.xml'
+            }
+            // Record maven,java warnings
+            recordIssues enabledForFailure: true, skipPublishingChecks:true, tools: [mavenConsole(), java()]
         }
     }
 }

--- a/examples/org.eclipse.glsp.example.workflow/pom.xml
+++ b/examples/org.eclipse.glsp.example.workflow/pom.xml
@@ -53,7 +53,7 @@
 	<properties>
 		<package-type>eclipse-plugin</package-type>
 	</properties>
-	
+
 	<dependencies>
 		<dependency>
 			<groupId>com.google.inject</groupId>
@@ -81,7 +81,7 @@
 			<version>0.5.0</version>
 		</dependency>
 	</dependencies>
-	
+
 	<profiles>
 		<profile>
 			<id>m2</id>
@@ -93,25 +93,6 @@
 			</properties>
 			<build>
 				<plugins>
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>build-helper-maven-plugin</artifactId>
-						<version>1.7</version>
-						<executions>
-							<execution>
-								<id>add-source</id>
-								<phase>generate-sources</phase>
-								<goals>
-									<goal>add-source</goal>
-								</goals>
-								<configuration>
-									<sources>
-										<source>src-gen</source>
-									</sources>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-deploy-plugin</artifactId>
@@ -132,48 +113,8 @@
 				<plugins>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-dependency-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>copy-dependencies</id>
-								<phase>package</phase>
-								<goals>
-									<goal>copy-dependencies</goal>
-								</goals>
-								<configuration>
-									<outputDirectory>${project.build.directory}/libs</outputDirectory>
-									<overWriteReleases>false</overWriteReleases>
-									<overWriteSnapshots>false</overWriteSnapshots>
-									<overWriteIfNewer>true</overWriteIfNewer>
-									<excludeTransitive>false</excludeTransitive>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>com.googlecode.addjars-maven-plugin</groupId>
-						<artifactId>addjars-maven-plugin</artifactId>
-						<version>1.0.5</version>
-						<executions>
-							<execution>
-								<phase>package</phase>
-								<goals>
-									<goal>add-jars</goal>
-								</goals>
-								<configuration>
-									<resources>
-										<resource>
-											<directory>${project.build.directory}/libs</directory>
-										</resource>
-									</resources>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-shade-plugin</artifactId>
-						<version>3.0.0</version>
+						<version>3.2.4</version>
 						<configuration>
 							<transformers>
 								<transformer
@@ -181,14 +122,21 @@
 									<mainClass>org.eclipse.glsp.example.workflow.launch.WorkflowServerLauncher</mainClass>
 								</transformer>
 							</transformers>
+							<artifactSet>
+								<excludes>
+									<exclude>javax.websocket:javax.websocket-client-api</exclude>
+								</excludes>
+							</artifactSet>
 							<filters>
 								<filter>
 									<artifact>*:*</artifact>
 									<excludes>
-										<exclude>META-INF/INDEX.LIST</exclude>
-										<exclude>META-INF/*.SF</exclude>
-										<exclude>META-INF/*.DSA</exclude>
-										<exclude>META-INF/*.RSA</exclude>
+										<exclude>META-INF/MANIFEST.MF</exclude>
+										<exclude>META-INF/DEPENDENCIES</exclude>
+										<exclude>META-INF/ECLIPSE_*</exclude>
+										<exclude>META-INF/LICENSE*</exclude>
+										<exclude>META-INF/services/javax.servlet.ServletContainerInitializer*</exclude>
+										<exclude>META-INF/NOTICE*</exclude>
 										<exclude>.options</exclude>
 										<exclude>.api_description</exclude>
 										<exclude>*.profile</exclude>
@@ -199,6 +147,8 @@
 										<exclude>modeling32.png</exclude>
 										<exclude>systembundle.properties</exclude>
 										<exclude>profile.list</exclude>
+										<exclude>module-info.class</exclude>
+										<exclude>plugin.properties</exclude>
 										<exclude>**/*._trace</exclude>
 										<exclude>**/*.g</exclude>
 										<exclude>**/*.tokens</exclude>

--- a/plugins/org.eclipse.glsp.graph/pom.xml
+++ b/plugins/org.eclipse.glsp.graph/pom.xml
@@ -89,25 +89,6 @@
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>build-helper-maven-plugin</artifactId>
-						<version>1.7</version>
-						<executions>
-							<execution>
-								<id>add-source</id>
-								<phase>generate-sources</phase>
-								<goals>
-									<goal>add-source</goal>
-								</goals>
-								<configuration>
-									<sources>
-										<source>src-gen</source>
-									</sources>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-deploy-plugin</artifactId>
 						<version>2.8</version>

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GArgumentableImpl.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GArgumentableImpl.java
@@ -114,8 +114,7 @@ public class GArgumentableImpl extends MinimalEObjectImpl.Container implements G
          case GraphPackage.GARGUMENTABLE__ARGS:
             if (coreType)
                return getArgs();
-            else
-               return getArgs().map();
+            return getArgs().map();
       }
       return super.eGet(featureID, resolve, coreType);
    }

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GCompartmentImpl.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GCompartmentImpl.java
@@ -571,8 +571,7 @@ public class GCompartmentImpl extends GArgumentableImpl implements GCompartment 
          case GraphPackage.GCOMPARTMENT__LAYOUT_OPTIONS:
             if (coreType)
                return getLayoutOptions();
-            else
-               return getLayoutOptions().map();
+            return getLayoutOptions().map();
       }
       return super.eGet(featureID, resolve, coreType);
    }

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GEdgePlacementImpl.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GEdgePlacementImpl.java
@@ -302,6 +302,7 @@ public class GEdgePlacementImpl extends MinimalEObjectImpl.Container implements 
     * <!-- end-user-doc -->
     * @generated
     */
+   @SuppressWarnings("null")
    @Override
    public boolean eIsSet(int featureID) {
       switch (featureID) {

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GGraphImpl.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GGraphImpl.java
@@ -247,8 +247,7 @@ public class GGraphImpl extends GModelRootImpl implements GGraph {
          case GraphPackage.GGRAPH__LAYOUT_OPTIONS:
             if (coreType)
                return getLayoutOptions();
-            else
-               return getLayoutOptions().map();
+            return getLayoutOptions().map();
       }
       return super.eGet(featureID, resolve, coreType);
    }

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GLabelImpl.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GLabelImpl.java
@@ -621,8 +621,7 @@ public class GLabelImpl extends GAlignableImpl implements GLabel {
          case GraphPackage.GLABEL__ARGS:
             if (coreType)
                return getArgs();
-            else
-               return getArgs().map();
+            return getArgs().map();
          case GraphPackage.GLABEL__ID:
             return getId();
          case GraphPackage.GLABEL__CSS_CLASSES:

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GNodeImpl.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GNodeImpl.java
@@ -636,8 +636,7 @@ public class GNodeImpl extends GArgumentableImpl implements GNode {
          case GraphPackage.GNODE__LAYOUT_OPTIONS:
             if (coreType)
                return getLayoutOptions();
-            else
-               return getLayoutOptions().map();
+            return getLayoutOptions().map();
       }
       return super.eGet(featureID, resolve, coreType);
    }

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
 		<java.source>11</java.source>
 		<java.target>11</java.target>
 		<project.build.java.target>11</project.build.java.target>
-		<target.version>0.9.0-SNAPSHOT</target.version>
 	</properties>
 
 	<build>
@@ -65,6 +64,7 @@
 				<configuration>
 					<source>${java.source}</source>
 					<target>${java.target}</target>
+					<generatedSourcesDirectory>src-gen</generatedSourcesDirectory>
 				</configuration>
 			</plugin>
 		</plugins>
@@ -91,10 +91,9 @@
 			</activation>
 
 			<properties>
-				<tycho-version>2.2.0</tycho-version>
-				<tychoExtrasVersion>2.2.0</tychoExtrasVersion>
+				<tycho-version>2.3.0</tycho-version>
 				<maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
-
+				<target.version>0.9.0-SNAPSHOT</target.version>
 			</properties>
 
 			<modules>
@@ -154,7 +153,7 @@
 							<source>${java.source}</source>
 							<target>${java.target}</target>
 							<optimize>true</optimize>
-							<showWarnings>true</showWarnings>
+							<showWarnings>false</showWarnings>
 						</configuration>
 					</plugin>
 					<plugin>
@@ -229,13 +228,10 @@
 				<activeByDefault>false</activeByDefault>
 			</activation>
 
-			<repositories>
-				<repository>
-					<id>sonatype</id>
-					<name>Sonatype</name>
-					<url>https://oss.sonatype.org/content/groups/public</url>
-				</repository>
-			</repositories>
+			<properties>
+				<checkstyle.plugin>3.1.2</checkstyle.plugin>
+				<checkstyle>8.39</checkstyle>
+			</properties>
 
 			<modules>
 				<module>plugins/org.eclipse.glsp.graph</module>
@@ -287,23 +283,22 @@
 							</argLine>
 						</configuration>
 					</plugin>
-
 					<!-- to disable use -Dcheckstyle.skip -->
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-checkstyle-plugin</artifactId>
-						<version>3.1.0</version>
+						<version>${checkstyle.plugin}</version>
 						<configuration>
 							<configLocation>emfcloud-checkstyle.xml</configLocation>
 							<consoleOutput>true</consoleOutput>
-							<sourceDirectories>src</sourceDirectories>
+							<excludes>**/src-gen/**/*.java</excludes>
 						</configuration>
 						<executions>
 							<execution>
+								<phase>validate</phase>
 								<goals>
 									<goal>check</goal>
 								</goals>
-								<phase>verify</phase>
 							</execution>
 						</executions>
 						<dependencies>
@@ -315,7 +310,7 @@
 							<dependency>
 								<groupId>com.puppycrawl.tools</groupId>
 								<artifactId>checkstyle</artifactId>
-								<version>8.29</version>
+								<version>${checkstyle}</version>
 							</dependency>
 						</dependencies>
 					</plugin>

--- a/releng/org.eclipse.glsp.repository/pom.xml
+++ b/releng/org.eclipse.glsp.repository/pom.xml
@@ -13,6 +13,14 @@
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-publisher-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<profiles>JavaSE-11</profiles>
+				</configuration>
+			</plugin>
 			<!-- Skip cleaning of this module otherwise the release build is not working 
 				on the jenkins instance -->
 			<plugin>
@@ -24,7 +32,7 @@
 			</plugin>
 		</plugins>
 	</build>
-	
+
 	<profiles>
 		<profile>
 			<id>p2-release</id>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -41,22 +41,22 @@
 							<version>${tycho-version}</version>
 						</plugin>
 						<plugin>
-							<groupId>org.eclipse.tycho.extras</groupId>
-							<artifactId>tycho-source-feature-plugin</artifactId>
-							<version>${tychoExtrasVersion}</version>
+							<groupId>org.eclipse.tycho</groupId>
+							<artifactId>tycho-source-plugin</artifactId>
+							<version>${tycho-version}</version>
 						</plugin>
 					</plugins>
 				</pluginManagement>
 				<plugins>
 					<plugin>
-						<groupId>org.eclipse.tycho.extras</groupId>
-						<artifactId>tycho-source-feature-plugin</artifactId>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-source-plugin</artifactId>
 						<executions>
 							<execution>
-								<id>source-feature</id>
+								<id>feature-source</id>
 								<phase>package</phase>
 								<goals>
-									<goal>source-feature</goal>
+									<goal>feature-source</goal>
 								</goals>
 								<configuration>
 									<excludes>


### PR DESCRIPTION
Jenkinsfile:
- Replace `--batch-mode` with shorthand notation and remove unnecessary `package` argument
- Move testing and codestyle checks into separate stages
- Enable checkstyle reporting & publishing as Github check for m2 build
- Publish Junit report as Github check
- Record maven and java warnings


Maven build
- Update metdata
- Update to tycho 2.3.0
- Define src-gen directory in maven-compiler-plugin instead of using the additional builder-helper-maven-plugin
- Replace deprecated typcho-source-feature-plugin
- Improve fatjar profile to fix build warnings regarding overlapping classes.

Java Code:
- Fix warnings in glsp-graph src-gen classes

Part of eclipse-glsp/glsp/issues/60
Part of eclipse-glsp/glsp/issues/17