### PR TITLE
#260 Update to Guice 5.0.1

### DIFF
--- a/examples/org.eclipse.glsp.example.workflow/pom.xml
+++ b/examples/org.eclipse.glsp.example.workflow/pom.xml
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>com.google.inject</groupId>
 			<artifactId>guice</artifactId>
-			<version>3.0</version>
+			<version>5.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.glsp</groupId>
@@ -66,7 +66,20 @@
 		<dependency>
 			<groupId>org.eclipse.elk</groupId>
 			<artifactId>org.eclipse.elk.alg.layered</artifactId>
-			<version>0.5.0</version>
+			<version>0.7.1</version>
+			<!-- Can be removed once https://github.com/eclipse-glsp/glsp/issues/265 
+				is resolved -->
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>27.1-jre</version>
 		</dependency>
 	</dependencies>
 

--- a/plugins/org.eclipse.glsp.graph/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.graph/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Require-Bundle: org.eclipse.emf.common;bundle-version="2.15.0",
  com.google.gson,
  org.eclipse.emf.ecore;bundle-version="2.15.0";visibility:=reexport,
  org.apache.log4j;bundle-version="1.2.15";visibility:=reexport,
- com.google.guava;bundle-version="21.0.0";visibility:=reexport
+ com.google.guava;bundle-version="27.1.0";visibility:=reexport
 Export-Package: org.eclipse.glsp.graph,
  org.eclipse.glsp.graph,
  org.eclipse.glsp.graph.builder,

--- a/plugins/org.eclipse.glsp.layout/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.layout/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Vendor: EclispeSource
 Automatic-Module-Name: org.eclipse.glsp.layout
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.glsp.server;bundle-version="0.9.0",
- org.eclipse.elk.core;bundle-version="0.5.0",
- org.eclipse.elk.graph;bundle-version="0.5.0",
- com.google.guava;bundle-version="21.0.0"
+ org.eclipse.elk.core;bundle-version="0.7.1",
+ org.eclipse.elk.graph;bundle-version="0.7.1",
+ com.google.guava;bundle-version="27.1.0"
 Export-Package: org.eclipse.glsp.layout

--- a/plugins/org.eclipse.glsp.layout/pom.xml
+++ b/plugins/org.eclipse.glsp.layout/pom.xml
@@ -50,12 +50,21 @@
 		<dependency>
 			<groupId>org.eclipse.elk</groupId>
 			<artifactId>org.eclipse.elk.core</artifactId>
-			<version>0.5.0</version>
+			<version>0.7.1</version>
+			<!-- Can be removed once https://github.com/eclipse-glsp/glsp/issues/265 
+				is resolved -->
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
+
 		<dependency>
 			<groupId>org.eclipse.elk</groupId>
 			<artifactId>org.eclipse.elk.graph.text</artifactId>
-			<version>0.5.0</version>
+			<version>0.7.1</version>
 		</dependency>
 	</dependencies>
 

--- a/plugins/org.eclipse.glsp.server/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.server/META-INF/MANIFEST.MF
@@ -12,10 +12,9 @@ Require-Bundle: org.apache.commons.io;bundle-version="2.2.0",
  org.eclipse.lsp4j;bundle-version="0.9.0",
  org.eclipse.lsp4j.jsonrpc,
  org.apache.commons.cli;bundle-version="1.4.0";visibility:=reexport,
- com.google.inject;bundle-version="3.0.0";visibility:=reexport,
+ com.google.inject;bundle-version="5.0.1";visibility:=reexport,
  javax.websocket;bundle-version="1.0.0";visibility:=reexport,
  org.eclipse.glsp.graph;bundle-version="[0.9.0,1.0.0)";visibility:=reexport
-Import-Package: com.google.inject.multibindings;version="1.3.0"
 Export-Package: org.eclipse.glsp.server.actions,
  org.eclipse.glsp.server.di,
  org.eclipse.glsp.server.diagram,

--- a/plugins/org.eclipse.glsp.server/pom.xml
+++ b/plugins/org.eclipse.glsp.server/pom.xml
@@ -45,12 +45,7 @@
 		<dependency>
 			<groupId>com.google.inject</groupId>
 			<artifactId>guice</artifactId>
-			<version>3.0</version>
-		</dependency>
-		<dependency>
-			<groupId>com.google.inject.extensions</groupId>
-			<artifactId>guice-multibindings</artifactId>
-			<version>3.0</version>
+			<version>5.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>21.0</version>
+			<version>27.1-jre</version>
 		</dependency>
 	</dependencies>
 
@@ -166,7 +166,6 @@
 						<!-- enable automated version updates -->
 						<groupId>org.eclipse.tycho</groupId>
 						<artifactId>tycho-versions-plugin</artifactId>
-						<version>${tycho-version}</version>
 					</plugin>
 					<plugin>
 						<groupId>org.eclipse.tycho</groupId>
@@ -195,7 +194,7 @@
 								<artifact>
 									<groupId>org.eclipse.glsp</groupId>
 									<artifactId>org.eclipse.glsp.parent</artifactId>
-									<classifier>targetplatforms/r2020-06</classifier>
+									<classifier>targetplatforms/r2021-03</classifier>
 									<version>${project.version}</version>
 								</artifact>
 							</target>

--- a/releng/org.eclipse.glsp.feature/feature.xml
+++ b/releng/org.eclipse.glsp.feature/feature.xml
@@ -312,19 +312,21 @@ version(s), and exceptions or additional permissions here}.&quot;
    </url>
 
    <requires>
-      <import plugin="com.google.inject" version="3.0.0" match="greaterOrEqual"/>
-      <import plugin="org.eclipse.lsp4j"/>
-      <import plugin="org.eclipse.lsp4j.jsonrpc" version="0.6.0" match="greaterOrEqual"/>
-      <import plugin="javax.websocket" version="1.0.0" match="greaterOrEqual"/>
-      <import plugin="org.eclipse.glsp.graph" version="0.9.0" match="greaterOrEqual"/>
-      <import plugin="com.google.gson"/>
       <import plugin="org.apache.commons.io" version="2.2.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.emf.ecore.change" version="2.13.0" match="greaterOrEqual"/>
       <import plugin="com.google.gson" version="2.8.2" match="greaterOrEqual"/>
-      <import plugin="com.google.guava" version="21.0.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.lsp4j" version="0.9.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.lsp4j.jsonrpc"/>
+      <import plugin="org.apache.commons.cli" version="1.4.0" match="greaterOrEqual"/>
+      <import plugin="com.google.inject" version="5.0.1" match="greaterOrEqual"/>
+      <import plugin="javax.websocket" version="1.0.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.glsp.graph" version="0.9.0" match="compatible"/>
+      <import plugin="org.junit"/>
+      <import plugin="org.junit.jupiter.api"/>
       <import plugin="org.eclipse.emf.common" version="2.15.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.emf.ecore" version="2.15.0" match="greaterOrEqual"/>
       <import plugin="org.apache.log4j" version="1.2.15" match="greaterOrEqual"/>
+      <import plugin="com.google.guava" version="27.1.0" match="greaterOrEqual"/>
    </requires>
 
    <plugin

--- a/targetplatforms/.project
+++ b/targetplatforms/.project
@@ -6,6 +6,11 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.jdt.core.javabuilder</name>
 			<arguments>
 			</arguments>
@@ -19,5 +24,6 @@
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
 </projectDescription>

--- a/targetplatforms/r2021-03.target
+++ b/targetplatforms/r2021-03.target
@@ -1,37 +1,36 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="2020-06 - Release" sequenceNumber="1597185458">
+<target name="2021-03 - Release" sequenceNumber="1627995717">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.2.600.v20200521-1852"/>
-      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.800.v20200514-1529"/>
-      <unit id="org.eclipse.emf.sdk.feature.group" version="2.22.0.v20200519-1135"/>
-      <repository location="http://download.eclipse.org/releases/2020-06"/>
+      <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.2.800.v20200916-1234"/>
+      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.1100.v20210209-1541"/>
+      <unit id="org.eclipse.emf.sdk.feature.group" version="2.25.0.v20210114-1734"/>
+      <repository location="http://download.eclipse.org/releases/2021-03"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.apache.log4j" version="1.2.15.v201012070815"/>
       <unit id="org.apache.commons.cli" version="1.4.0.v20200417-1444"/>
-      <unit id="org.apache.commons.io" version="2.6.0.v20190123-2029"/>
+      <unit id="org.apache.commons.io" version="2.8.0.v20210415-0900"/>
       <unit id="javax.servlet" version="3.1.0.v201410161800"/>
-      <unit id="com.google.gson" version="2.8.2.v20180104-1110"/>
-      <unit id="com.google.inject" version="3.0.0.v201605172100"/>
-      <unit id="com.google.inject.multibindings" version="3.0.0.v201605172100"/>
+      <unit id="com.google.gson" version="2.8.6.v20201231-1626"/>
+      <unit id="com.google.inject" version="5.0.1.v20210324-2015"/>
       <unit id="com.google.guava" version="27.1.0.v20190517-1946"/>
       <unit id="org.junit" version="4.12.0.v201504281640"/>
-      <unit id="org.junit.jupiter.api" version="5.6.0.v20200203-2009"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository/"/>
+      <unit id="org.junit.jupiter.api" version="5.7.1.v20210222-1948"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.jetty.bundles.f.feature.group" version="9.4.14.v20181113"/>
       <repository location="https://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.14.v20181113/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.elk.core" version="0.6.0"/>
-      <unit id="org.eclipse.elk.graph" version="0.6.0"/>
-      <unit id="org.eclipse.elk.graph.text" version="0.6.0"/>
-      <unit id="org.eclipse.elk.alg.layered" version="0.6.0"/>
-      <repository location="https://download.eclipse.org/elk/updates/releases/0.6.0/"/>
+      <unit id="org.eclipse.elk.core" version="0.7.1"/>
+      <unit id="org.eclipse.elk.graph" version="0.7.1"/>
+      <unit id="org.eclipse.elk.graph.text" version="0.7.1"/>
+      <unit id="org.eclipse.elk.alg.layered" version="0.7.1"/>
+      <repository location="https://download.eclipse.org/elk/updates/releases/0.7.1/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.lsp4j" version="0.0.0"/>

--- a/targetplatforms/r2021-03.tpd
+++ b/targetplatforms/r2021-03.tpd
@@ -1,29 +1,28 @@
-target "2020-06 - Release" with source requirements
+target "2021-03 - Release" with source requirements
 
-location "http://download.eclipse.org/releases/2020-06" {
+location "http://download.eclipse.org/releases/2021-03" {
 	org.eclipse.equinox.p2.discovery.feature.feature.group
 	org.eclipse.equinox.executable.feature.group
 	org.eclipse.emf.sdk.feature.group
 }
 
-location "https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository/" {
+location "https://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository/" {
 	org.apache.log4j
 	org.apache.commons.cli
 	org.apache.commons.io
 	javax.servlet
 	com.google.gson [2.8.2,3.0.0)
-	com.google.inject [3.0.0,3.0.1)
-	com.google.inject.multibindings [3.0.0,3.0.1)
+	com.google.inject [5.0.1,5.0.2)
 	com.google.guava [27.1.0,27.1.1)
 	org.junit [4.12.0,4.13.0)
-	org.junit.jupiter.api [5.6.0,5.6.1)
+	org.junit.jupiter.api [5.7.1,5.7.2)
 }
 
 location "https://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.14.v20181113/" {
 	org.eclipse.jetty.bundles.f.feature.group
 }
 
-location "https://download.eclipse.org/elk/updates/releases/0.6.0/" {
+location "https://download.eclipse.org/elk/updates/releases/0.7.1/" {
 	org.eclipse.elk.core
 	org.eclipse.elk.graph
 	org.eclipse.elk.graph.text

--- a/tests/org.eclipse.glsp.graph.test/pom.xml
+++ b/tests/org.eclipse.glsp.graph.test/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.4.2</version>
+			<version>5.7.1</version>
 		</dependency>
 	</dependencies>
 

--- a/tests/org.eclipse.glsp.server.test/pom.xml
+++ b/tests/org.eclipse.glsp.server.test/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.4.2</version>
+			<version>5.7.1</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Update the dependencies to use the latest Guice version available in Orbit (5.0.1) and update the target platform definition to Eclipse 2021-03 to be in line with the TPD of the eclipse-integration.

This indirectly also enforces updates of jupiter, elk and guava dependencies.
This PR contains a workaround to bypass the guava version restriction for elk maven dependencies that can be removed once ELK 0.8.0 is released (this is tracked in  eclipse-glsp/glsp/issues/#265)

Resolves eclipse-glsp/glsp/issues/260