### PR TITLE
Bump Guava to version 30.1 to fix security alert

### DIFF
--- a/examples/org.eclipse.glsp.example.workflow/pom.xml
+++ b/examples/org.eclipse.glsp.example.workflow/pom.xml
@@ -79,7 +79,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>27.1-jre</version>
+			<version>30.1-jre</version>
 		</dependency>
 	</dependencies>
 

--- a/plugins/org.eclipse.glsp.graph/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.graph/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Require-Bundle: org.eclipse.emf.common;bundle-version="2.15.0",
  com.google.gson,
  org.eclipse.emf.ecore;bundle-version="2.15.0";visibility:=reexport,
  org.apache.log4j;bundle-version="1.2.15";visibility:=reexport,
- com.google.guava;bundle-version="27.1.0";visibility:=reexport
+ com.google.guava;bundle-version="30.1.0";visibility:=reexport
 Export-Package: org.eclipse.glsp.graph,
  org.eclipse.glsp.graph,
  org.eclipse.glsp.graph.builder,

--- a/plugins/org.eclipse.glsp.graph/pom.xml
+++ b/plugins/org.eclipse.glsp.graph/pom.xml
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>27.1-jre</version>
+			<version>30.1-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>

--- a/plugins/org.eclipse.glsp.layout/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.layout/META-INF/MANIFEST.MF
@@ -9,5 +9,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.glsp.server;bundle-version="0.9.0",
  org.eclipse.elk.core;bundle-version="0.7.1",
  org.eclipse.elk.graph;bundle-version="0.7.1",
- com.google.guava;bundle-version="27.1.0"
+ com.google.guava;bundle-version="30.1.0"
 Export-Package: org.eclipse.glsp.layout

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>27.1-jre</version>
+			<version>30.1-jre</version>
 		</dependency>
 	</dependencies>
 

--- a/releng/org.eclipse.glsp.feature/feature.xml
+++ b/releng/org.eclipse.glsp.feature/feature.xml
@@ -326,7 +326,7 @@ version(s), and exceptions or additional permissions here}.&quot;
       <import plugin="org.eclipse.emf.common" version="2.15.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.emf.ecore" version="2.15.0" match="greaterOrEqual"/>
       <import plugin="org.apache.log4j" version="1.2.15" match="greaterOrEqual"/>
-      <import plugin="com.google.guava" version="27.1.0" match="greaterOrEqual"/>
+      <import plugin="com.google.guava" version="30.1.0" match="greaterOrEqual"/>
    </requires>
 
    <plugin

--- a/targetplatforms/r2021-03.target
+++ b/targetplatforms/r2021-03.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="2021-03 - Release" sequenceNumber="1627995717">
+<target name="2021-03 - Release" sequenceNumber="1628018980">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.2.800.v20200916-1234"/>
@@ -16,7 +16,7 @@
       <unit id="javax.servlet" version="3.1.0.v201410161800"/>
       <unit id="com.google.gson" version="2.8.6.v20201231-1626"/>
       <unit id="com.google.inject" version="5.0.1.v20210324-2015"/>
-      <unit id="com.google.guava" version="27.1.0.v20190517-1946"/>
+      <unit id="com.google.guava" version="30.1.0.v20210127-2300"/>
       <unit id="org.junit" version="4.12.0.v201504281640"/>
       <unit id="org.junit.jupiter.api" version="5.7.1.v20210222-1948"/>
       <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository/"/>

--- a/targetplatforms/r2021-03.tpd
+++ b/targetplatforms/r2021-03.tpd
@@ -13,7 +13,7 @@ location "https://download.eclipse.org/tools/orbit/downloads/drops/R202106020316
 	javax.servlet
 	com.google.gson [2.8.2,3.0.0)
 	com.google.inject [5.0.1,5.0.2)
-	com.google.guava [27.1.0,27.1.1)
+	com.google.guava [30.1.0,31.0.0)
 	org.junit [4.12.0,4.13.0)
 	org.junit.jupiter.api [5.7.1,5.7.2)
 }


### PR DESCRIPTION
Fixes the following alert: https://github.com/eclipse-glsp/glsp-server/security/dependabot/examples/org.eclipse.glsp.example.workflow/pom.xml/com.google.guava:guava/open