### PR TITLE
Update maven build to fix security alert

### DIFF
--- a/releng/org.eclipse.glsp.repository/pom.xml
+++ b/releng/org.eclipse.glsp.repository/pom.xml
@@ -102,7 +102,7 @@
 								<repository>
 									<id>2019-09</id>
 									<layout>p2</layout>
-									<url>http://download.eclipse.org/releases/2019-09</url>
+									<url>https://download.eclipse.org/releases/2019-09</url>
 								</repository>
 							</repositories>
 							<dependencies>

--- a/targetplatforms/pom.xml
+++ b/targetplatforms/pom.xml
@@ -31,12 +31,12 @@
 						<repository>
 							<id>2020-06</id>
 							<layout>p2</layout>
-							<url>http://download.eclipse.org/releases/2020-06</url>
+							<url>https://download.eclipse.org/releases/2020-06</url>
 						</repository>
 						<repository>
 							<id>tpd</id>
 							<layout>p2</layout>
-							<url> http://download.eclipse.org/cbi/tpd/3.0.0-SNAPSHOT/</url>
+							<url> https://download.eclipse.org/cbi/tpd/3.0.0-SNAPSHOT/</url>
 						</repository>
 					</repositories>
 					<appArgLine>-consoleLog -application ${targetPlatform.application.name} ${targetPlatform.application.args}</appArgLine>


### PR DESCRIPTION
Fixes the following security alerts:
https://github.com/eclipse-glsp/glsp-server/security/code-scanning/1?query=ref%3Arefs%2Fheads%2Fmaster
https://github.com/eclipse-glsp/glsp-server/security/code-scanning/2?query=ref%3Arefs%2Fheads%2Fmaster