### PR TITLE
#406 Update to Theia 1.18.0 and switch to Codicons

### DIFF
--- a/examples/org.eclipse.glsp.example.workflow/src/org/eclipse/glsp/example/workflow/marker/WorkflowModelValidator.java
+++ b/examples/org.eclipse.glsp.example.workflow/src/org/eclipse/glsp/example/workflow/marker/WorkflowModelValidator.java
@@ -19,15 +19,19 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.eclipse.glsp.example.workflow.wfgraph.ActivityNode;
 import org.eclipse.glsp.example.workflow.wfgraph.TaskNode;
+import org.eclipse.glsp.graph.GCompartment;
 import org.eclipse.glsp.graph.GEdge;
+import org.eclipse.glsp.graph.GLabel;
 import org.eclipse.glsp.graph.GModelElement;
 import org.eclipse.glsp.server.features.validation.Marker;
 import org.eclipse.glsp.server.features.validation.MarkerKind;
 import org.eclipse.glsp.server.features.validation.ModelValidator;
 import org.eclipse.glsp.server.model.GModelState;
+import org.eclipse.glsp.server.utils.GModelUtil;
 
 public class WorkflowModelValidator implements ModelValidator {
 
@@ -57,7 +61,7 @@ public class WorkflowModelValidator implements ModelValidator {
    private static List<Marker> validateTaskNode(final GModelState modelState, final GModelElement taskNode) {
       List<Marker> markers = new ArrayList<>();
       validateTaskNode_isAutomated(modelState, taskNode).ifPresent(m -> markers.add(m));
-      validateTaskNode_nameStartsUpperCase(modelState, taskNode).ifPresent(m -> markers.add(m));
+      validateTaskNode_labelStartsUpperCase(modelState, taskNode).ifPresent(m -> markers.add(m));
       return markers;
    }
 
@@ -73,11 +77,15 @@ public class WorkflowModelValidator implements ModelValidator {
    }
 
    @SuppressWarnings("checkstyle:MethodName")
-   private static Optional<Marker> validateTaskNode_nameStartsUpperCase(final GModelState modelState,
+   private static Optional<Marker> validateTaskNode_labelStartsUpperCase(final GModelState modelState,
       final GModelElement element) {
       TaskNode taskNode = (TaskNode) element;
-      if (!Character.isUpperCase(taskNode.getName().charAt(0))) {
-         return Optional.of(new Marker("Task node name in upper case",
+      List<GCompartment> gCompartment = GModelUtil.filterByType(taskNode.getChildren(), GCompartment.class)
+         .collect(Collectors.toList());
+      List<GLabel> gLabels = GModelUtil.filterByType(gCompartment.get(0).getChildren(), GLabel.class)
+         .collect(Collectors.toList());
+      if (gLabels.size() > 0 && !Character.isUpperCase(gLabels.get(0).getText().charAt(0))) {
+         return Optional.of(new Marker("Task node label in upper case",
             "Task node names should start with upper case letters", element.getId(), MarkerKind.WARNING));
       }
       return Optional.empty();

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/internal/toolpalette/DefaultToolPaletteItemProvider.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/internal/toolpalette/DefaultToolPaletteItemProvider.java
@@ -48,8 +48,9 @@ public class DefaultToolPaletteItemProvider implements ToolPaletteItemProvider {
       counter = 0;
       List<PaletteItem> nodes = createPaletteItems(handlers, CreateNodeOperation.class);
       List<PaletteItem> edges = createPaletteItems(handlers, CreateEdgeOperation.class);
-      return Lists.newArrayList(PaletteItem.createPaletteGroup("node-group", "Nodes", nodes, "fa-hammer", "A"),
-         PaletteItem.createPaletteGroup("edge-group", "Edges", edges, "fa-hammer", "B"));
+      return Lists.newArrayList(
+         PaletteItem.createPaletteGroup("node-group", "Nodes", nodes, "symbol-property", "A"),
+         PaletteItem.createPaletteGroup("edge-group", "Edges", edges, "symbol-property", "B"));
 
    }
 


### PR DESCRIPTION
- Replace FontAwesome icons with codicons
- Fix validation of task node label
   - It is not possible to edit the name in this example, only the label text, therefore this validation rule could never return a result.

Part of eclipse-glsp/glsp/issues/406