### PR TITLE
#422 Cleanup ActionDispatcher API

### DIFF
--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/ActionDispatcher.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/ActionDispatcher.java
@@ -24,19 +24,8 @@ import org.eclipse.glsp.server.disposable.IDisposable;
 public interface ActionDispatcher extends IDisposable {
 
    /**
-    * @see ActionDispatcher#dispatch(Action)
-    *
-    * @param message ActionMessage received from the client
-    * @return
-    *         A {@link CompletableFuture} indicating when the action processing is complete
-    */
-   default CompletableFuture<Void> dispatch(final ActionMessage message) {
-      return dispatch(message.getAction());
-   }
-
-   /**
     * <p>
-    * Processes the given action, received from the specified clientId, by dispatching it to all registered handlers.
+    * Processes the given action by dispatching it to all registered handlers.
     * </p>
     *
     * @param action The action that should be dispatched.
@@ -47,7 +36,7 @@ public interface ActionDispatcher extends IDisposable {
 
    /**
     * <p>
-    * Processes all given actions, received from the specified clientId, by dispatching to the corresponding handlers.
+    * Processes all given actions by dispatching to the corresponding handlers.
     * </p>
     *
     * @param actions Actions to dispatch

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/launch/DefaultCLIParser.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/launch/DefaultCLIParser.java
@@ -75,7 +75,7 @@ public class DefaultCLIParser extends CLIParser {
       options.addOption(null, OPTION_FILE_LOG, true,
          String.format("Enable/Disable file logging. [default='%s']", DefaultOptions.FILE_LOG_ENABLED));
       options.addOption(null, OPTION_LOG_DIR, true,
-         String.format("Set the directory for log files (File logging has to be enabled). [default='%s']",
+         String.format("Set the directory for log files (File logging has to be enabled)",
             DefaultOptions.LOG_DIR));
       options.addOption(null, OPTION_LOG_LEVEL, true,
          String.format("Set the log level. [default='%s']", DefaultOptions.LOG_LEVEL));

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/protocol/DefaultGLSPServer.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/protocol/DefaultGLSPServer.java
@@ -173,7 +173,8 @@ public class DefaultGLSPServer implements GLSPServer {
       };
 
       try {
-         clientSessions.get(clientSessionId).getActionDispatcher().dispatch(message).exceptionally(errorHandler);
+         clientSessions.get(clientSessionId).getActionDispatcher().dispatch(message.getAction())
+            .exceptionally(errorHandler);
       } catch (RuntimeException e) {
          errorHandler.apply(e);
       }


### PR DESCRIPTION
Remove dispatch method for action messages from API. Action dispatchers are now client session specific and do not need the full message context anymore. The action object alone is enough.

Part of eclipse-glsp/glsp/issues/422