### PR TITLE
#441#219 Ensure that `newBounds` of ChangeBoundsAction are properly applied

### DIFF
--- a/examples/org.eclipse.glsp.example.workflow/src/org/eclipse/glsp/example/workflow/WorkflowDiagramConfiguration.java
+++ b/examples/org.eclipse.glsp.example.workflow/src/org/eclipse/glsp/example/workflow/WorkflowDiagramConfiguration.java
@@ -68,8 +68,8 @@ public class WorkflowDiagramConfiguration extends BaseDiagramConfiguration {
    @Override
    public List<ShapeTypeHint> getShapeTypeHints() {
       List<ShapeTypeHint> nodeHints = new ArrayList<>();
-      nodeHints.add(new ShapeTypeHint(MANUAL_TASK, true, true, false, true));
-      nodeHints.add(new ShapeTypeHint(AUTOMATED_TASK, true, true, false, true));
+      nodeHints.add(new ShapeTypeHint(MANUAL_TASK, true, true, true, true));
+      nodeHints.add(new ShapeTypeHint(AUTOMATED_TASK, true, true, true, true));
       ShapeTypeHint catHint = new ShapeTypeHint(CATEGORY, true, true, true, true);
       catHint.setContainableElementTypeIds(
          Arrays.asList(DECISION_NODE, MERGE_NODE, FORK_NODE, JOIN_NODE, AUTOMATED_TASK, MANUAL_TASK, CATEGORY));

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operations/gmodel/ChangeBoundsOperationHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operations/gmodel/ChangeBoundsOperationHandler.java
@@ -27,8 +27,8 @@ import org.eclipse.glsp.graph.GPoint;
 import org.eclipse.glsp.graph.builder.impl.GLayoutOptions;
 import org.eclipse.glsp.graph.util.GraphUtil;
 import org.eclipse.glsp.server.model.GModelState;
-import org.eclipse.glsp.server.operations.ChangeBoundsOperation;
 import org.eclipse.glsp.server.operations.AbstractOperationHandler;
+import org.eclipse.glsp.server.operations.ChangeBoundsOperation;
 import org.eclipse.glsp.server.types.ElementAndBounds;
 
 import com.google.inject.Inject;
@@ -67,9 +67,12 @@ public class ChangeBoundsOperationHandler extends AbstractOperationHandler<Chang
          // For child nodes (Owned by another node or compartment), restrict the movement
          // to positive coordinates, to avoid weird layout behavior
          : GraphUtil.point(Math.max(0, newPosition.getX()), Math.max(0, newPosition.getY()));
-
-      nodeToUpdate.getLayoutOptions().put(GLayoutOptions.KEY_PREF_WIDTH, newSize.getWidth());
-      nodeToUpdate.getLayoutOptions().put(GLayoutOptions.KEY_PREF_HEIGHT, newSize.getHeight());
+      if (nodeToUpdate.getLayout() != null) {
+         nodeToUpdate.getLayoutOptions().put(GLayoutOptions.KEY_PREF_WIDTH, newSize.getWidth());
+         nodeToUpdate.getLayoutOptions().put(GLayoutOptions.KEY_PREF_HEIGHT, newSize.getHeight());
+      } else {
+         nodeToUpdate.setSize(newSize);
+      }
 
       nodeToUpdate.setPosition(positionToSet);
    }


### PR DESCRIPTION
Update `ChangeBoundsOperationHandler` to update the element size instead of the PREF_WIDTH/HEIGHT layout options if the element is not layoutable (i.e. `layout` property is undefined)

Also: Make task nodes resizable to demonstrate that  eclipse-glsp/glsp/issues/219 has been fixed.
Fixes eclipse-glsp/glsp/issues/441
Close eclipse-glsp/glsp/issues/219