### PR TITLE
#467: Use graph as default root element instead of plain model root

### DIFF
--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/features/core/model/JsonFileGModelLoader.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/features/core/model/JsonFileGModelLoader.java
@@ -85,7 +85,7 @@ public class JsonFileGModelLoader implements ModelSourceLoader {
    }
 
    protected GModelRoot createNewEmptyRoot(final GModelState modelState) {
-      GModelRoot root = GraphFactory.eINSTANCE.createGModelRoot();
+      GModelRoot root = GraphFactory.eINSTANCE.createGGraph();
       root.setId(EMPTY_ROOT_ID);
       root.setType(DefaultTypes.GRAPH);
       return root;


### PR DESCRIPTION
Fixes https://github.com/eclipse-glsp/glsp/issues/467

![glsp_wrong_root_fix](https://user-images.githubusercontent.com/19170971/145009967-426a22d8-02ba-4eb9-9daf-d4dce794666b.gif)
