### PR TITLE
#534: Provide utility methods to properly match actual type argument

### DIFF
--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/AbstractActionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/AbstractActionHandler.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2021 EclipseSource and others.
+ * Copyright (c) 2019-2022 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/AbstractActionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/AbstractActionHandler.java
@@ -38,7 +38,7 @@ public abstract class AbstractActionHandler<A extends Action> implements ActionH
 
    @SuppressWarnings("unchecked")
    protected Class<A> deriveActionType() {
-      return (Class<A>) GenericsUtil.getGenericTypeParameterClass(getClass(), AbstractActionHandler.class);
+      return (Class<A>) GenericsUtil.getActualTypeArgument(getClass(), Action.class);
    }
 
    @Override

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/BasicActionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/BasicActionHandler.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2021 EclipseSource and others.
+ * Copyright (c) 2019-2022 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,7 +17,6 @@ package org.eclipse.glsp.server.actions;
 
 import java.util.List;
 
-import org.eclipse.glsp.server.internal.util.GenericsUtil;
 import org.eclipse.glsp.server.model.GModelState;
 
 import com.google.inject.Inject;
@@ -31,12 +30,6 @@ public abstract class BasicActionHandler<T extends Action> extends AbstractActio
 
    @Inject
    protected GModelState modelState;
-
-   @Override
-   @SuppressWarnings("unchecked")
-   protected Class<T> deriveActionType() {
-      return (Class<T>) GenericsUtil.getActualTypeArgument(getClass(), Action.class);
-   }
 
    @Override
    public List<Action> executeAction(final T actualAction) {

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/BasicActionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/BasicActionHandler.java
@@ -35,7 +35,7 @@ public abstract class BasicActionHandler<T extends Action> extends AbstractActio
    @Override
    @SuppressWarnings("unchecked")
    protected Class<T> deriveActionType() {
-      return (Class<T>) GenericsUtil.getGenericTypeParameterClass(getClass(), BasicActionHandler.class);
+      return (Class<T>) GenericsUtil.getActualTypeArgument(getClass(), Action.class);
    }
 
    @Override

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/ResponseAction.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/ResponseAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 EclipseSource and others.
+ * Copyright (c) 2019-2022 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/ResponseAction.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/ResponseAction.java
@@ -37,10 +37,8 @@ public class ResponseAction extends Action {
     */
    public static Action respond(final Action request, final Action response) {
       if (request instanceof RequestAction<?>) {
-         Class<?> responseType = GenericsUtil.getGenericTypeParameterClass(request.getClass(), RequestAction.class);
-         if (responseType.isInstance(response)) {
-            ((ResponseAction) response).setResponseId(((RequestAction<?>) request).getRequestId());
-         }
+         GenericsUtil.asActualTypeArgument(request.getClass(), ResponseAction.class, response)
+            .ifPresent(matchingResponse -> matchingResponse.setResponseId(((RequestAction<?>) request).getRequestId()));
       }
       return response;
    }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/internal/util/GenericsUtil.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/internal/util/GenericsUtil.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020 EclipseSource and others.
+ * Copyright (c) 2020-2022 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,6 +16,11 @@
 package org.eclipse.glsp.server.internal.util;
 
 import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.glsp.server.types.GLSPServerException;
 
 public final class GenericsUtil {
    private GenericsUtil() {}
@@ -30,5 +35,80 @@ public final class GenericsUtil {
    public static Class<?> getGenericTypeParameterClass(final Class<?> clazz, final Class<?> genericBaseclass) {
       return (Class<?>) (GenericsUtil.getParametrizedType(clazz, genericBaseclass))
          .getActualTypeArguments()[0];
+   }
+
+   /**
+    * This method will search for an actual type argument that matches the expected base type, starting from the given
+    * clazz up the complete class hierarchy. If the given type object matches the actual type argument, the type object
+    * is returns as that type.
+    *
+    * @param <T>        expected base type
+    * @param clazz      search start
+    * @param baseType   base type that matches the actual type argument
+    * @param typeObject the object that may implement the given type
+    * @return the given type object as the matching type
+    */
+   public static <T> Optional<? extends T> asActualTypeArgument(final Class<?> clazz, final Class<T> baseType,
+      final Object typeObject) {
+      return findActualTypeArgument(clazz, baseType)
+         .filter(matchingType -> matchingType.isInstance(typeObject))
+         .map(matchingType -> matchingType.cast(typeObject));
+   }
+
+   /**
+    * This method will search for an actual type argument that matches the expected base type, starting from the given
+    * clazz up the complete class hierarchy.
+    *
+    * @param <T>      expected base type
+    * @param clazz    search start
+    * @param baseType base type that matches the actual type argument
+    * @return the type argument that is closest to the given <code>clazz</code> and matches the given base base
+    */
+   public static <T> Class<? extends T> getActualTypeArgument(final Class<?> clazz, final Class<T> baseType) {
+      return findActualTypeArgument(clazz, baseType)
+         .orElseThrow(() -> new GLSPServerException("No matching type argument for " + baseType + " in " + clazz));
+   }
+
+   /**
+    * This method will search for an actual type argument that matches the expected base type, starting from the given
+    * clazz up the complete class hierarchy.
+    *
+    * @param <T>      expected base type
+    * @param clazz    search start
+    * @param baseType base type that matches the actual type argument
+    * @return the type argument that is closest to the given <code>clazz</code> and matches the given base base
+    */
+   public static <T> Optional<Class<? extends T>> findActualTypeArgument(final Class<?> clazz,
+      final Class<T> baseType) {
+      return findActualTypeArgument(clazz, baseType, null);
+   }
+
+   /**
+    * This method will search for an actual type argument that matches the expected base type, starting from the given
+    * clazz until the search stop.
+    *
+    * @param <T>        expected base type
+    * @param clazz      search start
+    * @param baseType   base type that matches the actual type argument
+    * @param searchStop search stop or <code>null</code> if we should search up to Object
+    * @return the type argument that is closest to the given <code>clazz</code> and matches the given base base
+    */
+   @SuppressWarnings("unchecked")
+   public static <T> Optional<Class<? extends T>> findActualTypeArgument(final Class<?> clazz,
+      final Class<T> baseType, final Class<?> searchStop) {
+      if (clazz == null || baseType == null) {
+         return Optional.empty();
+      }
+      if (clazz.getGenericSuperclass() instanceof ParameterizedType) {
+         ParameterizedType parameterizedType = (ParameterizedType) clazz.getGenericSuperclass();
+         for (Type typeArgument : parameterizedType.getActualTypeArguments()) {
+            if (typeArgument instanceof Class<?> && baseType.isAssignableFrom((Class<?>) typeArgument)) {
+               return Optional.of((Class<? extends T>) typeArgument);
+            }
+         }
+      }
+      return clazz.getSuperclass() == null || Objects.equals(clazz, searchStop)
+         ? Optional.empty()
+         : findActualTypeArgument(clazz.getSuperclass(), baseType, searchStop);
    }
 }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/internal/util/GenericsUtil.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/internal/util/GenericsUtil.java
@@ -93,7 +93,7 @@ public final class GenericsUtil {
     * @param searchStop search stop or <code>null</code> if we should search up to Object
     * @return the type argument that is closest to the given <code>clazz</code> and matches the given base base
     */
-   @SuppressWarnings("unchecked")
+   @SuppressWarnings({ "unchecked", "checkstyle:CyclomaticComplexity" })
    public static <T> Optional<Class<? extends T>> findActualTypeArgument(final Class<?> clazz,
       final Class<T> baseType, final Class<?> searchStop) {
       if (clazz == null || baseType == null) {

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operations/AbstractCreateOperationHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operations/AbstractCreateOperationHandler.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020 EclipseSource and others.
+ * Copyright (c) 2020-2022 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,8 +17,6 @@ package org.eclipse.glsp.server.operations;
 
 import java.util.List;
 
-import org.eclipse.glsp.server.internal.util.GenericsUtil;
-
 import com.google.common.collect.Lists;
 
 public abstract class AbstractCreateOperationHandler<T extends CreateOperation> extends AbstractOperationHandler<T>
@@ -31,12 +29,6 @@ public abstract class AbstractCreateOperationHandler<T extends CreateOperation> 
 
    public AbstractCreateOperationHandler(final List<String> handledElementTypeIds) {
       this.handledElementTypeIds = handledElementTypeIds;
-   }
-
-   @SuppressWarnings("unchecked")
-   @Override
-   protected Class<T> deriveOperationType() {
-      return (Class<T>) GenericsUtil.getActualTypeArgument(getClass(), CreateOperation.class);
    }
 
    @Override

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operations/AbstractCreateOperationHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operations/AbstractCreateOperationHandler.java
@@ -36,8 +36,7 @@ public abstract class AbstractCreateOperationHandler<T extends CreateOperation> 
    @SuppressWarnings("unchecked")
    @Override
    protected Class<T> deriveOperationType() {
-      return (Class<T>) (GenericsUtil.getParametrizedType(getClass(), AbstractCreateOperationHandler.class))
-         .getActualTypeArguments()[0];
+      return (Class<T>) GenericsUtil.getActualTypeArgument(getClass(), CreateOperation.class);
    }
 
    @Override

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operations/AbstractOperationHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operations/AbstractOperationHandler.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020-2021 EclipseSource and others.
+ * Copyright (c) 2020-2022 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operations/AbstractOperationHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operations/AbstractOperationHandler.java
@@ -36,8 +36,7 @@ public abstract class AbstractOperationHandler<O extends Operation> implements O
 
    @SuppressWarnings("unchecked")
    protected Class<O> deriveOperationType() {
-      return (Class<O>) (GenericsUtil.getParametrizedType(getClass(), AbstractOperationHandler.class))
-         .getActualTypeArguments()[0];
+      return (Class<O>) GenericsUtil.getActualTypeArgument(getClass(), Operation.class);
    }
 
    @Override

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operations/BasicCreateOperationHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operations/BasicCreateOperationHandler.java
@@ -44,8 +44,7 @@ public abstract class BasicCreateOperationHandler<T extends CreateOperation> ext
    @SuppressWarnings("unchecked")
    @Override
    protected Class<T> deriveOperationType() {
-      return (Class<T>) (GenericsUtil.getParametrizedType(getClass(), BasicCreateOperationHandler.class))
-         .getActualTypeArguments()[0];
+      return (Class<T>) GenericsUtil.getActualTypeArgument(getClass(), CreateOperation.class);
    }
 
    @Override

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operations/BasicCreateOperationHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operations/BasicCreateOperationHandler.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020-2021 EclipseSource and others.
+ * Copyright (c) 2020-2022 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,7 +17,6 @@ package org.eclipse.glsp.server.operations;
 
 import java.util.List;
 
-import org.eclipse.glsp.server.internal.util.GenericsUtil;
 import org.eclipse.glsp.server.model.GModelState;
 
 import com.google.common.collect.Lists;
@@ -39,12 +38,6 @@ public abstract class BasicCreateOperationHandler<T extends CreateOperation> ext
 
    public BasicCreateOperationHandler(final List<String> handledElementTypeIds) {
       this.handledElementTypeIds = handledElementTypeIds;
-   }
-
-   @SuppressWarnings("unchecked")
-   @Override
-   protected Class<T> deriveOperationType() {
-      return (Class<T>) GenericsUtil.getActualTypeArgument(getClass(), CreateOperation.class);
    }
 
    @Override

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operations/BasicOperationHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operations/BasicOperationHandler.java
@@ -38,8 +38,7 @@ public abstract class BasicOperationHandler<T extends Operation> extends Abstrac
    @Override
    @SuppressWarnings("unchecked")
    protected Class<T> deriveOperationType() {
-      return (Class<T>) (GenericsUtil.getParametrizedType(getClass(), BasicOperationHandler.class))
-         .getActualTypeArguments()[0];
+      return (Class<T>) GenericsUtil.getActualTypeArgument(getClass(), Operation.class);
    }
 
    protected abstract void executeOperation(T operation, GModelState modelState);

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operations/BasicOperationHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operations/BasicOperationHandler.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020-2021 EclipseSource and others.
+ * Copyright (c) 2020-2022 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,7 +15,6 @@
  ********************************************************************************/
 package org.eclipse.glsp.server.operations;
 
-import org.eclipse.glsp.server.internal.util.GenericsUtil;
 import org.eclipse.glsp.server.model.GModelState;
 
 import com.google.inject.Inject;
@@ -33,12 +32,6 @@ public abstract class BasicOperationHandler<T extends Operation> extends Abstrac
    @Override
    protected void executeOperation(final T operation) {
       executeOperation(operation, modelState);
-   }
-
-   @Override
-   @SuppressWarnings("unchecked")
-   protected Class<T> deriveOperationType() {
-      return (Class<T>) GenericsUtil.getActualTypeArgument(getClass(), Operation.class);
    }
 
    protected abstract void executeOperation(T operation, GModelState modelState);

--- a/tests/org.eclipse.glsp.server.test/pom.xml
+++ b/tests/org.eclipse.glsp.server.test/pom.xml
@@ -30,6 +30,11 @@
 			<artifactId>junit-jupiter-engine</artifactId>
 			<version>5.7.1</version>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
+			<version>5.7.1</version>
+		</dependency>
 	</dependencies>
 
 	<profiles>

--- a/tests/org.eclipse.glsp.server.test/src/org/eclipse/glsp/server/internal/util/GenericsUtilTest.java
+++ b/tests/org.eclipse.glsp.server.test/src/org/eclipse/glsp/server/internal/util/GenericsUtilTest.java
@@ -1,0 +1,190 @@
+/********************************************************************************
+ * Copyright (c) 2022 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.server.internal.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.eclipse.glsp.server.actions.Action;
+import org.eclipse.glsp.server.actions.RequestAction;
+import org.eclipse.glsp.server.actions.ResponseAction;
+import org.eclipse.glsp.server.features.core.model.RequestBoundsAction;
+import org.eclipse.glsp.server.features.core.model.RequestModelAction;
+import org.eclipse.glsp.server.features.core.model.SetBoundsAction;
+import org.eclipse.glsp.server.features.core.model.SetModelAction;
+import org.eclipse.glsp.server.features.directediting.ApplyLabelEditOperation;
+import org.eclipse.glsp.server.features.directediting.ApplyLabelEditOperationHandler;
+import org.eclipse.glsp.server.operations.CreateEdgeOperation;
+import org.eclipse.glsp.server.operations.Operation;
+import org.eclipse.glsp.server.operations.ReconnectEdgeOperation;
+import org.eclipse.glsp.server.operations.gmodel.CreateEdgeOperationHandler;
+import org.eclipse.glsp.server.operations.gmodel.ReconnectEdgeOperationHandler;
+import org.eclipse.glsp.server.types.GLSPServerException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class GenericsUtilTest {
+
+   public static class MyResponseAction extends ResponseAction {
+      public MyResponseAction() {
+         super("custom");
+      }
+
+      @Override
+      public int hashCode() {
+         return Objects.hash(getKind());
+      }
+
+      @Override
+      public boolean equals(final Object obj) {
+         if (this == obj) {
+            return true;
+         }
+         if (!(obj instanceof MyResponseAction)) {
+            return false;
+         }
+         Action other = (MyResponseAction) obj;
+         return Objects.equals(getKind(), other.getKind());
+      }
+   }
+
+   public static class MyResponseActionExt extends MyResponseAction {}
+
+   public static abstract class IntermediateRequestAction<T extends MyResponseAction> extends RequestAction<T> {
+      public IntermediateRequestAction(final String kind) {
+         super(kind);
+      }
+   }
+
+   public static class MyRequestAction extends IntermediateRequestAction<MyResponseAction> {
+      public MyRequestAction() {
+         super("myrequest");
+      }
+   }
+
+   public static class MySubRequestAction extends MyRequestAction {}
+
+   public static class MyRequestActionExt extends IntermediateRequestAction<MyResponseActionExt> {
+      public MyRequestActionExt() {
+         super("myrequestext");
+      }
+   }
+
+   private static Stream<Arguments> matchingRequestResponse() {
+      return Stream.of(
+         arguments(MyRequestAction.class, MyResponseAction.class),
+         arguments(MySubRequestAction.class, MyResponseAction.class),
+         arguments(MyRequestActionExt.class, MyResponseActionExt.class),
+         arguments(RequestModelAction.class, SetModelAction.class),
+         arguments(RequestBoundsAction.class, SetBoundsAction.class));
+   }
+
+   @ParameterizedTest
+   @MethodSource
+   void matchingRequestResponse(final Class<?> requestClass, final Class<?> expectedResponseClass)
+      throws IOException, InterruptedException {
+      assertEquals(expectedResponseClass, GenericsUtil.getActualTypeArgument(requestClass, ResponseAction.class));
+   }
+
+   private static Stream<Arguments> matchingOperationHandler() {
+      return Stream.of(
+         arguments(ApplyLabelEditOperationHandler.class, ApplyLabelEditOperation.class),
+         arguments(CreateEdgeOperationHandler.class, CreateEdgeOperation.class),
+         arguments(ReconnectEdgeOperationHandler.class, ReconnectEdgeOperation.class));
+   }
+
+   @ParameterizedTest
+   @MethodSource
+   void matchingOperationHandler(final Class<?> handlerClass, final Class<?> expectedOperationClass)
+      throws IOException, InterruptedException {
+      assertEquals(expectedOperationClass, GenericsUtil.getActualTypeArgument(handlerClass, Operation.class));
+   }
+
+   @ParameterizedTest
+   @MethodSource
+   void erroneousMatching(final Class<?> handlerClass, final Class<?> baseType)
+      throws IOException, InterruptedException {
+      assertThrows(GLSPServerException.class, () -> GenericsUtil.getActualTypeArgument(handlerClass, baseType));
+   }
+
+   private static Stream<Arguments> erroneousMatching() {
+      return Stream.of(
+         arguments(RequestBoundsAction.class, Operation.class),
+         arguments(ApplyLabelEditOperationHandler.class, ResponseAction.class),
+         arguments(RequestModelAction.class, MyResponseActionExt.class));
+   }
+
+   @ParameterizedTest
+   @MethodSource
+   void matchFinding(final Class<?> clazz, final Class<?> baseType, final Optional<Class<?>> expectedResult)
+      throws IOException, InterruptedException {
+      assertEquals(expectedResult, GenericsUtil.findActualTypeArgument(clazz, baseType));
+   }
+
+   private static Stream<Arguments> matchFinding() {
+      return Stream.of(
+         arguments(MyRequestAction.class, ResponseAction.class, Optional.of(MyResponseAction.class)),
+         arguments(MySubRequestAction.class, ResponseAction.class, Optional.of(MyResponseAction.class)),
+         arguments(MyRequestActionExt.class, ResponseAction.class, Optional.of(MyResponseActionExt.class)),
+         arguments(RequestModelAction.class, ResponseAction.class, Optional.of(SetModelAction.class)),
+         arguments(RequestModelAction.class, MyResponseActionExt.class, Optional.empty()),
+         arguments(ApplyLabelEditOperationHandler.class, Operation.class, Optional.of(ApplyLabelEditOperation.class)),
+         arguments(CreateEdgeOperationHandler.class, Operation.class, Optional.of(CreateEdgeOperation.class)),
+         arguments(CreateEdgeOperationHandler.class, ResponseAction.class, Optional.empty()),
+         arguments(null, null, Optional.empty()),
+         arguments(MyRequestAction.class, null, Optional.empty()),
+         arguments(null, ResponseAction.class, Optional.empty()));
+   }
+
+   @ParameterizedTest
+   @MethodSource
+   void asActualTypeArgument(final Class<?> clazz, final Class<?> baseType, final Object typeObject,
+      final Object expectedResult)
+      throws IOException, InterruptedException {
+      assertEquals(expectedResult, GenericsUtil.asActualTypeArgument(clazz, baseType, typeObject));
+   }
+
+   private static Stream<Arguments> asActualTypeArgument() {
+      return Stream.of(
+         arguments(MyRequestAction.class, ResponseAction.class, new MyResponseAction(),
+            Optional.of(new MyResponseAction())),
+         arguments(MyRequestAction.class, MyResponseAction.class, new MyResponseAction(),
+            Optional.of(new MyResponseAction())),
+         arguments(MyRequestAction.class, ResponseAction.class, new MyResponseActionExt(),
+            Optional.of(new MyResponseActionExt())),
+         arguments(MyRequestAction.class, MyResponseAction.class, new MyResponseActionExt(),
+            Optional.of(new MyResponseActionExt())),
+         arguments(MyRequestAction.class, MyResponseActionExt.class, new MyResponseActionExt(),
+            Optional.empty()),
+         arguments(MyRequestActionExt.class, ResponseAction.class, new MyResponseActionExt(),
+            Optional.of(new MyResponseActionExt())),
+         arguments(MyRequestActionExt.class, MyResponseAction.class, new MyResponseActionExt(),
+            Optional.of(new MyResponseActionExt())),
+         arguments(MyRequestActionExt.class, MyResponseActionExt.class, new MyResponseActionExt(),
+            Optional.of(new MyResponseActionExt())),
+         arguments(MyRequestActionExt.class, Operation.class, new MyResponseActionExt(),
+            Optional.empty()),
+         arguments(MyRequestActionExt.class, Object.class, new MyResponseActionExt(),
+            Optional.of(new MyResponseActionExt())));
+   }
+}

--- a/tests/org.eclipse.glsp.server.test/src/org/eclipse/glsp/server/internal/util/GenericsUtilTest.java
+++ b/tests/org.eclipse.glsp.server.test/src/org/eclipse/glsp/server/internal/util/GenericsUtilTest.java
@@ -70,7 +70,7 @@ public class GenericsUtilTest {
 
    public static class MyResponseActionExt extends MyResponseAction {}
 
-   public static abstract class IntermediateRequestAction<T extends MyResponseAction> extends RequestAction<T> {
+   public abstract static class IntermediateRequestAction<T extends MyResponseAction> extends RequestAction<T> {
       public IntermediateRequestAction(final String kind) {
          super(kind);
       }


### PR DESCRIPTION
- Ensure we start from the most specific class and climb up the type
hierarchy to search for the matching actual type argument

Part of https://github.com/eclipse-glsp/glsp/issues/534