### PR TITLE
Draft: Add an ActionExecutor which is responsible to execute the actions

### DIFF
--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/ActionDispatcher.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/ActionDispatcher.java
@@ -19,14 +19,13 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-import org.eclipse.glsp.server.disposable.IDisposable;
 import org.eclipse.glsp.server.features.core.model.UpdateModelAction;
 
 /**
  * The central component that process all {@link Action}s by dispatching them to their designated
  * handlers.
  */
-public interface ActionDispatcher extends IDisposable {
+public interface ActionDispatcher {
 
    /**
     * <p>

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/ActionExecutor.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/ActionExecutor.java
@@ -1,0 +1,40 @@
+/********************************************************************************
+ * Copyright (c) 2022 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.server.actions;
+
+import java.util.concurrent.Executor;
+
+import org.eclipse.glsp.server.disposable.IDisposable;
+
+/**
+ * FIXME add doc if approach is approved
+ */
+public interface ActionExecutor extends IDisposable, Executor {
+
+   /**
+    * Returns {@code true} if the given thread is an action executor thread.
+    *
+    * @return {@code true} if the given thread is an action executor thread
+    */
+   boolean isExecutorThread(Thread thread);
+
+   /**
+    * Returns {@code true} if this executor has been shut down.
+    *
+    * @return {@code true} if this executor has been shut down
+    */
+   boolean isShutdown();
+}

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/ServerModule.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/ServerModule.java
@@ -18,9 +18,11 @@ package org.eclipse.glsp.server.di;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.glsp.server.actions.ActionExecutor;
 import org.eclipse.glsp.server.actions.ActionRegistry;
 import org.eclipse.glsp.server.di.scope.DiagramGlobalScope;
 import org.eclipse.glsp.server.gson.ServerGsonConfigurator;
+import org.eclipse.glsp.server.internal.actions.DefaultActionExecutor;
 import org.eclipse.glsp.server.internal.actions.DefaultActionRegistry;
 import org.eclipse.glsp.server.internal.di.scope.DefaultDiagramGlobalScope;
 import org.eclipse.glsp.server.internal.gson.DefaultServerGsonConfigurator;
@@ -105,6 +107,7 @@ public class ServerModule extends GLSPModule {
       bind(ClientSessionManager.class).to(bindClientSessionManager()).in(Singleton.class);
 
       bind(ActionRegistry.class).to(bindActionRegistry()).in(Singleton.class);
+      bind(ActionExecutor.class).to(bindActionExecutor()).in(Singleton.class);
 
       bind(DiagramGlobalScope.class).to(bindDiagramGlobalScope()).in(Singleton.class);
    }
@@ -144,6 +147,10 @@ public class ServerModule extends GLSPModule {
 
    protected Class<? extends ActionRegistry> bindActionRegistry() {
       return DefaultActionRegistry.class;
+   }
+
+   protected Class<? extends ActionExecutor> bindActionExecutor() {
+      return DefaultActionExecutor.class;
    }
 
    protected Class<? extends DiagramGlobalScope> bindDiagramGlobalScope() {

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/internal/actions/DefaultActionDispatcher.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/internal/actions/DefaultActionDispatcher.java
@@ -21,53 +21,43 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.stream.Collectors;
 
 import org.apache.log4j.Logger;
 import org.eclipse.glsp.server.actions.Action;
 import org.eclipse.glsp.server.actions.ActionDispatcher;
+import org.eclipse.glsp.server.actions.ActionExecutor;
 import org.eclipse.glsp.server.actions.ActionHandler;
 import org.eclipse.glsp.server.actions.ActionHandlerRegistry;
 import org.eclipse.glsp.server.actions.ResponseAction;
 import org.eclipse.glsp.server.di.ClientId;
-import org.eclipse.glsp.server.disposable.Disposable;
 import org.eclipse.glsp.server.features.core.model.UpdateModelAction;
-import org.eclipse.glsp.server.protocol.GLSPClient;
 import org.eclipse.glsp.server.utils.FutureUtil;
 
 import com.google.inject.Inject;
-import com.google.inject.Provider;
 
 /**
  * <p>
- * An ActionDispatcher that executes all handlers in the same thread. The dispatcher's
+ * An ActionDispatcher that executes all handlers with the {@link ActionExecutor}. The dispatcher's
  * public methods can be invoked from any thread, e.g. from background jobs running on
  * the server.
  * </p>
  */
-public class DefaultActionDispatcher extends Disposable implements ActionDispatcher {
+public class DefaultActionDispatcher implements ActionDispatcher {
 
    private static final Logger LOG = Logger.getLogger(DefaultActionDispatcher.class);
-
-   private static final AtomicInteger COUNT = new AtomicInteger(0);
 
    @Inject
    protected ActionHandlerRegistry actionHandlerRegistry;
 
    @Inject
+   protected ActionExecutor actionExecutor;
+
+   @Inject
    @ClientId
    protected String clientId;
-
-   protected final String name;
-
-   protected final Thread thread;
-
-   protected final BlockingQueue<Action> actionsQueue = new ArrayBlockingQueue<>(100, true);
 
    protected List<Action> postUpdateQueue = new ArrayList<>();
 
@@ -75,26 +65,12 @@ public class DefaultActionDispatcher extends Disposable implements ActionDispatc
    // and will be removed from the dispatcher's thread.
    protected final Map<Action, CompletableFuture<Void>> results = Collections.synchronizedMap(new HashMap<>());
 
-   // Use a provider, as the GLSPClient is probably not created yet. We won't receive
-   // any action until it's ready anyway.
-   @Inject
-   protected Provider<GLSPClient> client;
-
-   public DefaultActionDispatcher() {
-      this.name = getClass().getSimpleName() + " " + COUNT.incrementAndGet();
-      this.thread = new Thread(this::runThread);
-      this.thread.setName(this.name);
-      this.thread.setDaemon(true);
-      this.thread.start();
-   }
-
    @Override
    public CompletableFuture<Void> dispatch(final Action action) {
-
       CompletableFuture<Void> result = new CompletableFuture<>();
       results.put(action, result);
-      if (thread == Thread.currentThread()) {
-         // Actions dispatched from the ActionDispatcher thread don't have to go back
+      if (actionExecutor.isExecutorThread(Thread.currentThread())) {
+         // Actions dispatched from the ActionExecutor don't have to go back
          // to the queue, as they are just fragments of the current action from the queue.
          // Process them immediately.
          handleAction(action);
@@ -110,65 +86,28 @@ public class DefaultActionDispatcher extends Disposable implements ActionDispatc
    }
 
    protected void addToQueue(final Action action) {
-      if (Thread.currentThread() == this.thread) {
-         LOG.error("Actions shouldn't be added to the actions queue from the dispatcher thread!");
-         // Handle the action immediately, to avoid deadlocks when the queue if full
-         handleAction(action);
-         return;
-      }
-      boolean success = actionsQueue.offer(action);
-      while (!success) {
-         if (!thread.isAlive() || thread.isInterrupted()) {
-            // This may happen if e.g. some background tasks were still running when the client disconnected.
-            // This (probably) isn't critical and can be safely ignored.
+      try {
+         actionExecutor.execute(() -> handleAction(action));
+      } catch (RejectedExecutionException ex) {
+         if (actionExecutor.isShutdown()) {
             LOG.warn(String.format(
-               "Received an action after the ActionDispatcher was stopped. Ignoring action: %s", action));
+               "Received an action after the ActionExecutor was stopped. Ignoring action: %s", action));
             return;
          }
-         try {
-            // The queue may be temporarily full because we receive a lot of actions (e.g. during initialization),
-            // but if this keeps failing for a long time, it might indicate a deadlock
-            success = actionsQueue.offer(action, 1, TimeUnit.SECONDS);
-            if (!success) {
-               LOG.warn(String.format("Actions queue is currently full for dispatcher %s ; retrying...", name));
-            }
-         } catch (final InterruptedException ex) {
-            break;
-         }
-      }
-   }
-
-   private void runThread() {
-      while (true) {
-         try {
-            handleNextAction();
-         } catch (final InterruptedException e) {
-            LOG.info(String.format("Terminating DefaultActionDispatcher thread %s", Thread.currentThread().getName()));
-            break;
-         }
-      }
-      LOG.info("Terminating DefaultActionDispatcher");
-   }
-
-   private void handleNextAction()
-      throws InterruptedException {
-      final Action action = actionsQueue.take();
-      if (action != null) {
-         handleAction(action);
+         throw new IllegalStateException("Action was rejected: " + action, ex);
       }
    }
 
    @SuppressWarnings("checkstyle:IllegalCatch")
    protected void handleAction(final Action action) {
-      checkThread();
       if (action == null) {
          LOG.warn(String.format("Received a null action for client %s", clientId));
          return;
       }
 
       try {
-         List<CompletableFuture<Void>> results = runAction(action);
-         CompletableFuture<Void> result = FutureUtil.aggregateResults(results);
+         List<CompletableFuture<Void>> actionResults = runAction(action);
+         CompletableFuture<Void> result = FutureUtil.aggregateResults(actionResults);
          result.thenAccept(any -> {
             this.results.remove(action).complete(null);
          }).exceptionally(t -> {
@@ -186,17 +125,17 @@ public class DefaultActionDispatcher extends Disposable implements ActionDispatc
          throw new IllegalArgumentException("No handler registered for action: " + action);
       }
 
-      List<CompletableFuture<Void>> results = new ArrayList<>();
+      List<CompletableFuture<Void>> actionResults = new ArrayList<>();
       for (final ActionHandler actionHandler : actionHandlers) {
          final List<Action> responses = actionHandler.execute(action).stream()
             .map(response -> ResponseAction.respond(action, response))
             .collect(Collectors.toList());
-         results.addAll(dispatchAll(responses));
+         actionResults.addAll(dispatchAll(responses));
          if (action instanceof UpdateModelAction) {
-            results.add(dispatchPostUpdateQueue());
+            actionResults.add(dispatchPostUpdateQueue());
          }
       }
-      return results;
+      return actionResults;
    }
 
    protected CompletableFuture<Void> dispatchPostUpdateQueue() {
@@ -204,19 +143,5 @@ public class DefaultActionDispatcher extends Disposable implements ActionDispatc
       postUpdateQueue.clear();
       dispatchAll(toDispatch);
       return CompletableFuture.completedFuture(null);
-   }
-
-   protected final void checkThread() {
-      if (Thread.currentThread() != thread) {
-         throw new IllegalStateException(
-            "This method should only be invoked from the ActionDispatcher's thread: " + name);
-      }
-   }
-
-   @Override
-   public void doDispose() {
-      if (thread.isAlive()) {
-         thread.interrupt();
-      }
    }
 }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/internal/actions/DefaultActionExecutor.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/internal/actions/DefaultActionExecutor.java
@@ -1,0 +1,91 @@
+/********************************************************************************
+ * Copyright (c) 2022 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.server.internal.actions;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.log4j.Logger;
+import org.eclipse.glsp.server.actions.ActionExecutor;
+import org.eclipse.glsp.server.disposable.Disposable;
+
+/**
+ * FIXME add doc if approach is approved
+ */
+public class DefaultActionExecutor extends Disposable implements ActionExecutor {
+
+   private static final Logger LOG = Logger.getLogger(DefaultActionExecutor.class);
+
+   protected final DefaultActionExecutorThreadFactory threadFactory = new DefaultActionExecutorThreadFactory(
+      DefaultActionExecutor.class.getSimpleName());
+   protected final ExecutorService executor = Executors.newSingleThreadExecutor(threadFactory);
+
+   @Override
+   public void execute(final Runnable command) {
+      executor.execute(command);
+   }
+
+   @Override
+   public boolean isExecutorThread(final Thread thread) {
+      return threadFactory.thread == thread;
+   }
+
+   @Override
+   public boolean isShutdown() { return executor.isShutdown(); }
+
+   @Override
+   protected void doDispose() {
+      super.doDispose();
+      executor.shutdown();
+      try {
+         if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+            executor.shutdownNow();
+            if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+               LOG.warn("Could not terminate executor thread's");
+            }
+         }
+      } catch (InterruptedException ie) {
+         executor.shutdownNow();
+         Thread.currentThread().interrupt();
+      }
+   }
+
+   protected static class DefaultActionExecutorThreadFactory implements ThreadFactory {
+
+      private static final AtomicInteger COUNT = new AtomicInteger(0);
+
+      protected final String name;
+      protected Thread thread;
+
+      protected DefaultActionExecutorThreadFactory(final String name) {
+         this.name = name;
+      }
+
+      @Override
+      public Thread newThread(final Runnable r) {
+         if (thread != null) {
+            LOG.warn("More than one thread is created for the action executor");
+         }
+         thread = new Thread(r, name + " " + COUNT.incrementAndGet());
+         thread.setDaemon(true);
+         return thread;
+      }
+
+   }
+}

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/internal/session/DefaultClientSession.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/internal/session/DefaultClientSession.java
@@ -47,14 +47,6 @@ public class DefaultClientSession extends Disposable implements ClientSession {
    public ActionDispatcher getActionDispatcher() { return actionDispatcher; }
 
    @Override
-   protected void doDispose() {
-      super.doDispose();
-      if (actionDispatcher != null) {
-         actionDispatcher.dispose();
-      }
-   }
-
-   @Override
    public Injector getInjector() { return injector; }
 
 }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/protocol/DefaultGLSPServer.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/protocol/DefaultGLSPServer.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import org.apache.log4j.Logger;
+import org.eclipse.glsp.server.actions.ActionExecutor;
 import org.eclipse.glsp.server.actions.ActionMessage;
 import org.eclipse.glsp.server.actions.ActionRegistry;
 import org.eclipse.glsp.server.session.ClientSession;
@@ -45,6 +46,9 @@ public class DefaultGLSPServer implements GLSPServer {
 
    @Inject
    protected ActionRegistry actionRegistry;
+
+   @Inject
+   protected ActionExecutor actionExecutor;
 
    protected GLSPClient clientProxy;
    protected CompletableFuture<InitializeResult> initialized;
@@ -189,6 +193,9 @@ public class DefaultGLSPServer implements GLSPServer {
       clientSessions.clear();
       initialized = new CompletableFuture<>();
       this.clientProxy = null;
+      if (actionExecutor != null) {
+         actionExecutor.dispose();
+      }
    }
 
    public String getApplicationId() { return applicationId; }


### PR DESCRIPTION
Fixes eclipse-glsp/glsp/issues/630

About new DefaultActionExecutor:
- Uses a SingleThreadExecutor (equal to old single Thread solution of
Action Dispatcher)
- Handles also the work queue (queue is removed form Action Dispatcher)
 - The work queue is now unbounded (before it was limited to 100
actions)
- Is configured on the ServerModule level as singleton