### PR TITLE
#622: Remove 'setRoot' from API in favor of 'updateRoot'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
   - `ModelSourceLoader` → `SourceModelStorage`
   - `ModelSourceWatcher` → `SourceModelWatcher`
   - Added method to `SourceModelStorage`
-- 
+- [server] Refactorings as part of adding new GLSP examples [#622](https://github.com/eclipse-glsp/glsp/issues/622) ([java: #159](https://github.com/eclipse-glsp/glsp-server/pull/159), [java: #161](https://github.com/eclipse-glsp/glsp-server/pull/161))
+  - Renamed `setRoot` to `updateRoot` in model state to better reflect dependent updates, remove re-generation of command stack in method but add index re-generation
 
 
 ## [v0.9.0- 09/12/2021](https://github.com/eclipse-glsp/glsp/releases/tag/0.9.0)

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/model/DefaultGModelState.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/model/DefaultGModelState.java
@@ -69,8 +69,7 @@ public class DefaultGModelState implements GModelState {
       return GModelIndex.get(newRoot);
    }
 
-   @Override
-   public void setRoot(final GModelRoot newRoot) { this.currentModel = newRoot; }
+   protected void setRoot(final GModelRoot newRoot) { this.currentModel = newRoot; }
 
    protected void setCommandStack(final CommandStack commandStack) {
       if (this.commandStack != null) {

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/model/ModelState.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/model/ModelState.java
@@ -32,8 +32,6 @@ interface ModelState<T> {
 
    T getRoot();
 
-   void setRoot(T newRoot);
-
    void updateRoot(T newRoot);
 
    boolean canUndo();


### PR DESCRIPTION
Part of https://github.com/eclipse-glsp/glsp/issues/622