### PR TITLE
#658 Fix console log level for WebsocketLauncher

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,17 +79,19 @@ To run the Workflow Diagram example server standalone JAR, run this command in y
 
 ```console
     usage: java -jar org.eclipse.glsp.example.workflow-X.X.X-glsp.jar [-c <arg>] [-d <arg>]
-        [-f <arg>] [-h] [-l <arg>] [-p <arg>] [-w]
+        [-f <arg>] [-h] [-l <arg>] [-p <arg>] [-v <arg>] [-w]
 
     options:
-    -c,--consoleLog <arg>   Enable/Disable console logging. [default='true']
-    -d,--logDir <arg>       Set the directory for log files (File logging has to be enabled)
-    -f,--fileLog <arg>      Enable/Disable file logging. [default='false']
-    -h,--help               Display usage information about GLSPServerLauncher
-    -l,--logLevel <arg>     Set the log level. [default='INFO']
-    -p,--port <arg>         Set server port. [default='5007']
-    -w,--websocket          Use websocket launcher instead of default launcher.
-                            [default='false']
+    -c,--consoleLog <arg>          Enable/Disable console logging. [default='true']
+    -d,--logDir <arg>              Set the directory for log files (File logging has to be
+                                    enabled)
+    -f,--fileLog <arg>             Enable/Disable file logging. [default='false']
+    -h,--help                      Display usage information about GLSPServerLauncher
+    -l,--logLevel <arg>            Set the log level. [default='INFO']
+    -p,--port <arg>                Set server port. [default='5007']
+    -v,--websocketLogLevel <arg>   Set the log level for the Jetty websocket server.
+                                    [default='INFO']
+    -w,--websocket                 Use websocket launcher instead of default launcher.
 ```
 
 Once the server is running, choose a diagram client integration (such as Eclipse Theia, VSCode, Eclipse, or Standalone) below.

--- a/README.md
+++ b/README.md
@@ -79,19 +79,19 @@ To run the Workflow Diagram example server standalone JAR, run this command in y
 
 ```console
     usage: java -jar org.eclipse.glsp.example.workflow-X.X.X-glsp.jar [-c <arg>] [-d <arg>]
-        [-f <arg>] [-h] [-l <arg>] [-p <arg>] [-v <arg>] [-w]
+        [-f <arg>] [-h] [-j <arg>] [-l <arg>] [-p <arg>] [-w]
 
     options:
-    -c,--consoleLog <arg>          Enable/Disable console logging. [default='true']
-    -d,--logDir <arg>              Set the directory for log files (File logging has to be
-                                    enabled)
-    -f,--fileLog <arg>             Enable/Disable file logging. [default='false']
-    -h,--help                      Display usage information about GLSPServerLauncher
-    -l,--logLevel <arg>            Set the log level. [default='INFO']
-    -p,--port <arg>                Set server port. [default='5007']
-    -v,--websocketLogLevel <arg>   Set the log level for the Jetty websocket server.
-                                    [default='INFO']
-    -w,--websocket                 Use websocket launcher instead of default launcher.
+    -c,--consoleLog <arg>      Enable/Disable console logging. [default='true']
+    -d,--logDir <arg>          Set the directory for log files (File logging has to be
+                                enabled)
+    -f,--fileLog <arg>         Enable/Disable file logging. [default='false']
+    -h,--help                  Display usage information about GLSPServerLauncher
+    -j,--jettyLogLevel <arg>   Set the log level for the Jetty websocket server.
+                                [default='INFO']
+    -l,--logLevel <arg>        Set the log level. [default='INFO']
+    -p,--port <arg>            Set server port. [default='5007']
+    -w,--websocket             Use websocket launcher instead of default launcher.
 ```
 
 Once the server is running, choose a diagram client integration (such as Eclipse Theia, VSCode, Eclipse, or Standalone) below.

--- a/examples/org.eclipse.glsp.example.workflow/src/org/eclipse/glsp/example/workflow/launch/WorkflowCLIParser.java
+++ b/examples/org.eclipse.glsp.example.workflow/src/org/eclipse/glsp/example/workflow/launch/WorkflowCLIParser.java
@@ -22,7 +22,7 @@ import org.eclipse.glsp.server.launch.DefaultCLIParser;
 
 public class WorkflowCLIParser extends DefaultCLIParser {
    public static final String OPTION_WEBSOCKET = "websocket";
-   public static final String OPTION_WEBSOCKET_LOG_LEVEL = "websocketLogLevel";
+   public static final String OPTION_JETTY_LOG_LEVEL = "jettyLogLevel";
 
    public static final class WorkflowOptions {
       public static final Level WEBSOCKET_LOG_LEVEL = Level.INFO;
@@ -36,7 +36,7 @@ public class WorkflowCLIParser extends DefaultCLIParser {
    public boolean isWebsocket() { return hasOption(OPTION_WEBSOCKET); }
 
    public Level parseWebsocketLogLevel() {
-      String levelArg = parseOption(OPTION_WEBSOCKET_LOG_LEVEL, WorkflowOptions.WEBSOCKET_LOG_LEVEL.toString());
+      String levelArg = parseOption(OPTION_JETTY_LOG_LEVEL, WorkflowOptions.WEBSOCKET_LOG_LEVEL.toString());
       return Level.toLevel(levelArg, WorkflowOptions.WEBSOCKET_LOG_LEVEL);
    }
 
@@ -44,7 +44,7 @@ public class WorkflowCLIParser extends DefaultCLIParser {
       Options options = DefaultCLIParser.getDefaultOptions();
       options.addOption("w", OPTION_WEBSOCKET, false,
          "Use websocket launcher instead of default launcher.");
-      options.addOption("v", OPTION_WEBSOCKET_LOG_LEVEL, true,
+      options.addOption("j", OPTION_JETTY_LOG_LEVEL, true,
          "Set the log level for the Jetty websocket server. [default='INFO']");
       return options;
    }

--- a/examples/org.eclipse.glsp.example.workflow/src/org/eclipse/glsp/example/workflow/launch/WorkflowCLIParser.java
+++ b/examples/org.eclipse.glsp.example.workflow/src/org/eclipse/glsp/example/workflow/launch/WorkflowCLIParser.java
@@ -17,10 +17,16 @@ package org.eclipse.glsp.example.workflow.launch;
 
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.apache.logging.log4j.Level;
 import org.eclipse.glsp.server.launch.DefaultCLIParser;
 
 public class WorkflowCLIParser extends DefaultCLIParser {
    public static final String OPTION_WEBSOCKET = "websocket";
+   public static final String OPTION_WEBSOCKET_LOG_LEVEL = "websocketLogLevel";
+
+   public static final class WorkflowOptions {
+      public static final Level WEBSOCKET_LOG_LEVEL = Level.INFO;
+   }
 
    public WorkflowCLIParser(final String[] args, final String processName)
       throws ParseException {
@@ -29,10 +35,17 @@ public class WorkflowCLIParser extends DefaultCLIParser {
 
    public boolean isWebsocket() { return hasOption(OPTION_WEBSOCKET); }
 
+   public Level parseWebsocketLogLevel() {
+      String levelArg = parseOption(OPTION_WEBSOCKET_LOG_LEVEL, WorkflowOptions.WEBSOCKET_LOG_LEVEL.toString());
+      return Level.toLevel(levelArg, WorkflowOptions.WEBSOCKET_LOG_LEVEL);
+   }
+
    public static Options getDefaultOptions() {
       Options options = DefaultCLIParser.getDefaultOptions();
       options.addOption("w", OPTION_WEBSOCKET, false,
-         "Use websocket launcher instead of default launcher. [default='false']");
+         "Use websocket launcher instead of default launcher.");
+      options.addOption("v", OPTION_WEBSOCKET_LOG_LEVEL, true,
+         "Set the log level for the Jetty websocket server. [default='INFO']");
       return options;
    }
 

--- a/examples/org.eclipse.glsp.example.workflow/src/org/eclipse/glsp/example/workflow/launch/WorkflowServerLauncher.java
+++ b/examples/org.eclipse.glsp.example.workflow/src/org/eclipse/glsp/example/workflow/launch/WorkflowServerLauncher.java
@@ -40,7 +40,7 @@ public final class WorkflowServerLauncher {
             .configureDiagramModule(new WorkflowDiagramModule());
 
          GLSPServerLauncher launcher = parser.isWebsocket()
-            ? new WebsocketServerLauncher(workflowServerModule, "/workflow")
+            ? new WebsocketServerLauncher(workflowServerModule, "/workflow", parser.parseWebsocketLogLevel())
             : new SocketGLSPServerLauncher(workflowServerModule);
 
          launcher.start("localhost", port, parser);

--- a/plugins/org.eclipse.glsp.server.websocket/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.server.websocket/META-INF/MANIFEST.MF
@@ -22,4 +22,5 @@ Require-Bundle: javax.websocket;bundle-version="1.0.0";visibility:=reexport,
 Export-Package: org.eclipse.glsp.server.websocket
 Import-Package: javax.servlet;version="[3.1.0,4.0.0)",
  org.apache.logging.log4j;version="2.17.1",
+ org.apache.logging.log4j.core.config;version="2.17.1",
  org.apache.logging.log4j.spi;version="2.17.1"

--- a/plugins/org.eclipse.glsp.server.websocket/src/org/eclipse/glsp/server/websocket/WebsocketServerLauncher.java
+++ b/plugins/org.eclipse.glsp.server.websocket/src/org/eclipse/glsp/server/websocket/WebsocketServerLauncher.java
@@ -21,12 +21,15 @@ import java.net.InetSocketAddress;
 import javax.websocket.server.ServerContainer;
 import javax.websocket.server.ServerEndpointConfig;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.eclipse.glsp.server.di.ServerModule;
 import org.eclipse.glsp.server.launch.GLSPServerLauncher;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.websocket.jsr356.server.deploy.WebSocketServerContainerInitializer;
 
@@ -37,18 +40,27 @@ public class WebsocketServerLauncher extends GLSPServerLauncher {
    protected Server server;
    protected String clientAppPath;
    protected final String endpointPath;
+   protected final Level websocketLogLevel;
 
    public WebsocketServerLauncher(final ServerModule serverModule, final String endpointPath,
       final Module... additionalModules) {
+      this(serverModule, endpointPath, Level.INFO, additionalModules);
+   }
+
+   public WebsocketServerLauncher(final ServerModule serverModule, final String endpointPath, final Level websocketLogLevel,
+      final Module... additionalModules) {
       super(serverModule, additionalModules);
       this.endpointPath = endpointPath.startsWith("/") ? endpointPath.substring(1) : endpointPath;
+      this.websocketLogLevel = websocketLogLevel;
    }
 
    @Override
    @SuppressWarnings("checkstyle:IllegalCatch")
    public void start(final String hostname, final int port) {
       try {
-         org.eclipse.jetty.util.log.Log.setLog(new Log4j2Logger("WebsocketServerLauncher"));
+         Log.setLog(new Log4j2Logger("WebsocketServerLauncher"));
+         Configurator.setLevel("org.eclipse.jetty", this.websocketLogLevel);
+
          // Setup Jetty Server
          server = new Server(new InetSocketAddress(hostname, port));
          ServletContextHandler webAppContext;


### PR DESCRIPTION
- Make console log level for websocket jetty server configurable (is Level WARN by default)
- Update README

Resolves https://github.com/eclipse-glsp/glsp/issues/658