### PR TITLE
#635: Execute all pending actions before disposing action dispatcher

### DIFF
--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/DiagramModule.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/DiagramModule.java
@@ -313,6 +313,7 @@ public abstract class DiagramModule extends GLSPModule {
 
    protected void configureActionHandlers(final MultiBinding<ActionHandler> binding) {
       binding.add(ClientActionHandler.class);
+      binding.add(DefaultActionDispatcher.class);
       binding.add(OperationActionHandler.class);
       binding.add(RequestModelActionHandler.class);
       binding.add(RequestPopupModelActionHandler.class);


### PR DESCRIPTION
Client session listeners only get notified about the session disposal after the session and its action dispatcher are disposed. As they might perform some cleanup we should ensure that all pending actions are executed before the action dispatcher is disposed and the listeners are notified.

Fixes https://github.com/eclipse-glsp/glsp/issues/635