### PR TITLE
#694: Add Layoutable interface

### DIFF
--- a/plugins/org.eclipse.glsp.graph/model/glsp-graph.ecore
+++ b/plugins/org.eclipse.glsp.graph/model/glsp-graph.ecore
@@ -15,11 +15,8 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="type" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="GShapeElement" abstract="true" interface="true"
-      eSuperTypes="#//GModelElement #//GBoundsAware"/>
-  <eClassifiers xsi:type="ecore:EClass" name="GGraph" eSuperTypes="#//GModelRoot #//GBoundsAware">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="layoutOptions" upperBound="-1"
-        eType="#//StringToObjectMapEntry" containment="true"/>
-  </eClassifiers>
+      eSuperTypes="#//GModelElement #//GBoundsAware #//GLayoutable"/>
+  <eClassifiers xsi:type="ecore:EClass" name="GGraph" eSuperTypes="#//GModelRoot #//GBoundsAware #//GLayoutable"/>
   <eClassifiers xsi:type="ecore:EClass" name="GModelRoot" eSuperTypes="#//GModelElement">
     <eStructuralFeatures xsi:type="ecore:EReference" name="canvasBounds" eType="#//GBounds"
         containment="true"/>
@@ -87,10 +84,9 @@
         defaultValueLiteral="left"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="rotate" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="GLayouting" abstract="true" interface="true">
+  <eClassifiers xsi:type="ecore:EClass" name="GLayouting" abstract="true" interface="true"
+      eSuperTypes="#//GLayoutable">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="layout" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="layoutOptions" upperBound="-1"
-        eType="#//StringToObjectMapEntry" containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="GBounds">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="x" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDouble"
@@ -131,5 +127,9 @@
   <eClassifiers xsi:type="ecore:EClass" name="StringToObjectMapEntry" instanceClassName="java.util.Map$Entry">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="key" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EJavaObject"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="GLayoutable">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="layoutOptions" upperBound="-1"
+        eType="#//StringToObjectMapEntry" containment="true"/>
   </eClassifiers>
 </ecore:EPackage>

--- a/plugins/org.eclipse.glsp.graph/model/glsp-graph.genmodel
+++ b/plugins/org.eclipse.glsp.graph/model/glsp-graph.genmodel
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <genmodel:GenModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"
-    xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" copyrightText=" Copyright (c) 2019-2021 EclipseSource and others.&#xA;&#xA;This program and the accompanying materials are made available under the&#xA;terms of the Eclipse Public License v. 2.0 which is available at&#xA;https://www.eclipse.org/legal/epl-2.0.&#xA;&#xA;This Source Code may also be made available under the following Secondary&#xA;Licenses when the conditions for such availability set forth in the Eclipse&#xA;Public License v. 2.0 are satisfied: GNU General Public License, version 2&#xA; with the GNU Classpath Exception which is available at&#xA; https://www.gnu.org/software/classpath/license.html.&#xA;&#xA;SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0&#xA; ********************************************************************************"
+    xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" copyrightText=" Copyright (c) 2019-2022 EclipseSource and others.&#xA;&#xA;This program and the accompanying materials are made available under the&#xA;terms of the Eclipse Public License v. 2.0 which is available at&#xA;https://www.eclipse.org/legal/epl-2.0.&#xA;&#xA;This Source Code may also be made available under the following Secondary&#xA;Licenses when the conditions for such availability set forth in the Eclipse&#xA;Public License v. 2.0 are satisfied: GNU General Public License, version 2&#xA; with the GNU Classpath Exception which is available at&#xA; https://www.gnu.org/software/classpath/license.html.&#xA;&#xA;SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0&#xA; ********************************************************************************"
     modelDirectory="/org.eclipse.glsp.graph/src-gen" creationCommands="false" creationIcons="false"
     editDirectory="" editorDirectory="" modelPluginID="" modelName="org.eclipse.glsp.graph"
     editPluginClass="org.eclipse.glsp.graph.provider.GlspgraphEditPlugin" updateClasspath="false"
@@ -26,9 +26,7 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute glsp-graph.ecore#//GModelElement/type"/>
     </genClasses>
     <genClasses image="false" ecoreClass="glsp-graph.ecore#//GShapeElement"/>
-    <genClasses ecoreClass="glsp-graph.ecore#//GGraph">
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference glsp-graph.ecore#//GGraph/layoutOptions"/>
-    </genClasses>
+    <genClasses ecoreClass="glsp-graph.ecore#//GGraph"/>
     <genClasses ecoreClass="glsp-graph.ecore#//GModelRoot">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference glsp-graph.ecore#//GModelRoot/canvasBounds"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute glsp-graph.ecore#//GModelRoot/revision"/>
@@ -76,7 +74,6 @@
     </genClasses>
     <genClasses image="false" ecoreClass="glsp-graph.ecore#//GLayouting">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute glsp-graph.ecore#//GLayouting/layout"/>
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference glsp-graph.ecore#//GLayouting/layoutOptions"/>
     </genClasses>
     <genClasses ecoreClass="glsp-graph.ecore#//GBounds">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute glsp-graph.ecore#//GBounds/x"/>
@@ -104,6 +101,9 @@
     <genClasses ecoreClass="glsp-graph.ecore#//StringToObjectMapEntry">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute glsp-graph.ecore#//StringToObjectMapEntry/key"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute glsp-graph.ecore#//StringToObjectMapEntry/value"/>
+    </genClasses>
+    <genClasses ecoreClass="glsp-graph.ecore#//GLayoutable">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference glsp-graph.ecore#//GLayoutable/layoutOptions"/>
     </genClasses>
   </genPackages>
 </genmodel:GenModel>

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/GGraph.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/GGraph.java
@@ -16,36 +16,16 @@
  */
 package org.eclipse.glsp.graph;
 
-import org.eclipse.emf.common.util.EMap;
-
 /**
  * <!-- begin-user-doc -->
  * A representation of the model object '<em><b>GGraph</b></em>'.
  * <!-- end-user-doc -->
  *
- * <p>
- * The following features are supported:
- * </p>
- * <ul>
- *   <li>{@link org.eclipse.glsp.graph.GGraph#getLayoutOptions <em>Layout Options</em>}</li>
- * </ul>
  *
  * @see org.eclipse.glsp.graph.GraphPackage#getGGraph()
  * @model
  * @generated
  */
-public interface GGraph extends GModelRoot, GBoundsAware {
-   /**
-    * Returns the value of the '<em><b>Layout Options</b></em>' map.
-    * The key is of type {@link java.lang.String},
-    * and the value is of type {@link java.lang.Object},
-    * <!-- begin-user-doc -->
-    * <!-- end-user-doc -->
-    * @return the value of the '<em>Layout Options</em>' map.
-    * @see org.eclipse.glsp.graph.GraphPackage#getGGraph_LayoutOptions()
-    * @model mapType="org.eclipse.glsp.graph.StringToObjectMapEntry&lt;org.eclipse.emf.ecore.EString, org.eclipse.emf.ecore.EJavaObject&gt;"
-    * @generated
-    */
-   EMap<String, Object> getLayoutOptions();
+public interface GGraph extends GModelRoot, GBoundsAware, GLayoutable {
 
 } // GGraph

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/GLayoutable.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/GLayoutable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2021 EclipseSource and others.
+ * Copyright (c) 2019-2022 EclipseSource and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,43 +16,38 @@
  */
 package org.eclipse.glsp.graph;
 
+import org.eclipse.emf.common.util.EMap;
+
+import org.eclipse.emf.ecore.EObject;
+
 /**
  * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>GLayouting</b></em>'.
+ * A representation of the model object '<em><b>GLayoutable</b></em>'.
  * <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * </p>
  * <ul>
- *   <li>{@link org.eclipse.glsp.graph.GLayouting#getLayout <em>Layout</em>}</li>
+ *   <li>{@link org.eclipse.glsp.graph.GLayoutable#getLayoutOptions <em>Layout Options</em>}</li>
  * </ul>
  *
- * @see org.eclipse.glsp.graph.GraphPackage#getGLayouting()
- * @model interface="true" abstract="true"
+ * @see org.eclipse.glsp.graph.GraphPackage#getGLayoutable()
+ * @model
  * @generated
  */
-public interface GLayouting extends GLayoutable {
+public interface GLayoutable extends EObject {
    /**
-    * Returns the value of the '<em><b>Layout</b></em>' attribute.
+    * Returns the value of the '<em><b>Layout Options</b></em>' map.
+    * The key is of type {@link java.lang.String},
+    * and the value is of type {@link java.lang.Object},
     * <!-- begin-user-doc -->
     * <!-- end-user-doc -->
-    * @return the value of the '<em>Layout</em>' attribute.
-    * @see #setLayout(String)
-    * @see org.eclipse.glsp.graph.GraphPackage#getGLayouting_Layout()
-    * @model
+    * @return the value of the '<em>Layout Options</em>' map.
+    * @see org.eclipse.glsp.graph.GraphPackage#getGLayoutable_LayoutOptions()
+    * @model mapType="org.eclipse.glsp.graph.StringToObjectMapEntry&lt;org.eclipse.emf.ecore.EString, org.eclipse.emf.ecore.EJavaObject&gt;"
     * @generated
     */
-   String getLayout();
+   EMap<String, Object> getLayoutOptions();
 
-   /**
-    * Sets the value of the '{@link org.eclipse.glsp.graph.GLayouting#getLayout <em>Layout</em>}' attribute.
-    * <!-- begin-user-doc -->
-    * <!-- end-user-doc -->
-    * @param value the new value of the '<em>Layout</em>' attribute.
-    * @see #getLayout()
-    * @generated
-    */
-   void setLayout(String value);
-
-} // GLayouting
+} // GLayoutable

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/GShapeElement.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/GShapeElement.java
@@ -26,4 +26,4 @@ package org.eclipse.glsp.graph;
  * @model interface="true" abstract="true"
  * @generated
  */
-public interface GShapeElement extends GModelElement, GBoundsAware {} // GShapeElement
+public interface GShapeElement extends GModelElement, GBoundsAware, GLayoutable {} // GShapeElement

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/GraphFactory.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/GraphFactory.java
@@ -207,12 +207,21 @@ public interface GraphFactory extends EFactory {
    GShapePreRenderedElement createGShapePreRenderedElement();
 
    /**
-   	 * Returns the package supported by this factory.
-   	 * <!-- begin-user-doc -->
+    * Returns a new object of class '<em>GLayoutable</em>'.
+    * <!-- begin-user-doc -->
     * <!-- end-user-doc -->
-   	 * @return the package supported by this factory.
-   	 * @generated
-   	 */
+    * @return a new object of class '<em>GLayoutable</em>'.
+    * @generated
+    */
+   GLayoutable createGLayoutable();
+
+   /**
+    * Returns the package supported by this factory.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @return the package supported by this factory.
+    * @generated
+    */
    GraphPackage getGraphPackage();
 
 } //GraphFactory

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/GraphPackage.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/GraphPackage.java
@@ -291,13 +291,22 @@ public interface GraphPackage extends EPackage {
    int GSHAPE_ELEMENT__SIZE = GMODEL_ELEMENT_FEATURE_COUNT + 1;
 
    /**
+    * The feature id for the '<em><b>Layout Options</b></em>' map.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    * @ordered
+    */
+   int GSHAPE_ELEMENT__LAYOUT_OPTIONS = GMODEL_ELEMENT_FEATURE_COUNT + 2;
+
+   /**
     * The number of structural features of the '<em>GShape Element</em>' class.
     * <!-- begin-user-doc -->
     * <!-- end-user-doc -->
     * @generated
     * @ordered
     */
-   int GSHAPE_ELEMENT_FEATURE_COUNT = GMODEL_ELEMENT_FEATURE_COUNT + 2;
+   int GSHAPE_ELEMENT_FEATURE_COUNT = GMODEL_ELEMENT_FEATURE_COUNT + 3;
 
    /**
     * The number of operations of the '<em>GShape Element</em>' class.
@@ -645,6 +654,15 @@ public interface GraphPackage extends EPackage {
    int GNODE__SIZE = GSHAPE_ELEMENT__SIZE;
 
    /**
+    * The feature id for the '<em><b>Layout Options</b></em>' map.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    * @ordered
+    */
+   int GNODE__LAYOUT_OPTIONS = GSHAPE_ELEMENT__LAYOUT_OPTIONS;
+
+   /**
     * The feature id for the '<em><b>Edge Placement</b></em>' containment reference.
     * <!-- begin-user-doc -->
     * <!-- end-user-doc -->
@@ -663,22 +681,13 @@ public interface GraphPackage extends EPackage {
    int GNODE__LAYOUT = GSHAPE_ELEMENT_FEATURE_COUNT + 1;
 
    /**
-    * The feature id for the '<em><b>Layout Options</b></em>' map.
-    * <!-- begin-user-doc -->
-    * <!-- end-user-doc -->
-    * @generated
-    * @ordered
-    */
-   int GNODE__LAYOUT_OPTIONS = GSHAPE_ELEMENT_FEATURE_COUNT + 2;
-
-   /**
     * The number of structural features of the '<em>GNode</em>' class.
     * <!-- begin-user-doc -->
     * <!-- end-user-doc -->
     * @generated
     * @ordered
     */
-   int GNODE_FEATURE_COUNT = GSHAPE_ELEMENT_FEATURE_COUNT + 3;
+   int GNODE_FEATURE_COUNT = GSHAPE_ELEMENT_FEATURE_COUNT + 2;
 
    /**
     * The number of operations of the '<em>GNode</em>' class.
@@ -926,6 +935,15 @@ public interface GraphPackage extends EPackage {
    int GCOMPARTMENT__SIZE = GSHAPE_ELEMENT__SIZE;
 
    /**
+    * The feature id for the '<em><b>Layout Options</b></em>' map.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    * @ordered
+    */
+   int GCOMPARTMENT__LAYOUT_OPTIONS = GSHAPE_ELEMENT__LAYOUT_OPTIONS;
+
+   /**
     * The feature id for the '<em><b>Layout</b></em>' attribute.
     * <!-- begin-user-doc -->
     * <!-- end-user-doc -->
@@ -935,22 +953,13 @@ public interface GraphPackage extends EPackage {
    int GCOMPARTMENT__LAYOUT = GSHAPE_ELEMENT_FEATURE_COUNT + 0;
 
    /**
-    * The feature id for the '<em><b>Layout Options</b></em>' map.
-    * <!-- begin-user-doc -->
-    * <!-- end-user-doc -->
-    * @generated
-    * @ordered
-    */
-   int GCOMPARTMENT__LAYOUT_OPTIONS = GSHAPE_ELEMENT_FEATURE_COUNT + 1;
-
-   /**
     * The number of structural features of the '<em>GCompartment</em>' class.
     * <!-- begin-user-doc -->
     * <!-- end-user-doc -->
     * @generated
     * @ordered
     */
-   int GCOMPARTMENT_FEATURE_COUNT = GSHAPE_ELEMENT_FEATURE_COUNT + 2;
+   int GCOMPARTMENT_FEATURE_COUNT = GSHAPE_ELEMENT_FEATURE_COUNT + 1;
 
    /**
     * The number of operations of the '<em>GCompartment</em>' class.
@@ -1108,13 +1117,22 @@ public interface GraphPackage extends EPackage {
    int GLABEL__SIZE = GALIGNABLE_FEATURE_COUNT + 9;
 
    /**
+    * The feature id for the '<em><b>Layout Options</b></em>' map.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    * @ordered
+    */
+   int GLABEL__LAYOUT_OPTIONS = GALIGNABLE_FEATURE_COUNT + 10;
+
+   /**
     * The feature id for the '<em><b>Text</b></em>' attribute.
     * <!-- begin-user-doc -->
     * <!-- end-user-doc -->
     * @generated
     * @ordered
     */
-   int GLABEL__TEXT = GALIGNABLE_FEATURE_COUNT + 10;
+   int GLABEL__TEXT = GALIGNABLE_FEATURE_COUNT + 11;
 
    /**
     * The number of structural features of the '<em>GLabel</em>' class.
@@ -1123,7 +1141,7 @@ public interface GraphPackage extends EPackage {
     * @generated
     * @ordered
     */
-   int GLABEL_FEATURE_COUNT = GALIGNABLE_FEATURE_COUNT + 11;
+   int GLABEL_FEATURE_COUNT = GALIGNABLE_FEATURE_COUNT + 12;
 
    /**
     * The number of operations of the '<em>GLabel</em>' class.
@@ -1224,6 +1242,15 @@ public interface GraphPackage extends EPackage {
     * @ordered
     */
    int GISSUE_MARKER__SIZE = GSHAPE_ELEMENT__SIZE;
+
+   /**
+    * The feature id for the '<em><b>Layout Options</b></em>' map.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    * @ordered
+    */
+   int GISSUE_MARKER__LAYOUT_OPTIONS = GSHAPE_ELEMENT__LAYOUT_OPTIONS;
 
    /**
     * The feature id for the '<em><b>Issues</b></em>' containment reference list.
@@ -1344,6 +1371,15 @@ public interface GraphPackage extends EPackage {
    int GPORT__SIZE = GSHAPE_ELEMENT__SIZE;
 
    /**
+    * The feature id for the '<em><b>Layout Options</b></em>' map.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    * @ordered
+    */
+   int GPORT__LAYOUT_OPTIONS = GSHAPE_ELEMENT__LAYOUT_OPTIONS;
+
+   /**
     * The number of structural features of the '<em>GPort</em>' class.
     * <!-- begin-user-doc -->
     * <!-- end-user-doc -->
@@ -1451,6 +1487,15 @@ public interface GraphPackage extends EPackage {
     * @ordered
     */
    int GBUTTON__SIZE = GSHAPE_ELEMENT__SIZE;
+
+   /**
+    * The feature id for the '<em><b>Layout Options</b></em>' map.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    * @ordered
+    */
+   int GBUTTON__LAYOUT_OPTIONS = GSHAPE_ELEMENT__LAYOUT_OPTIONS;
 
    /**
     * The feature id for the '<em><b>Enabled</b></em>' attribute.
@@ -1719,6 +1764,43 @@ public interface GraphPackage extends EPackage {
    int GEDGE_PLACEMENT_OPERATION_COUNT = 0;
 
    /**
+    * The meta object id for the '{@link org.eclipse.glsp.graph.impl.GLayoutableImpl <em>GLayoutable</em>}' class.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @see org.eclipse.glsp.graph.impl.GLayoutableImpl
+    * @see org.eclipse.glsp.graph.impl.GraphPackageImpl#getGLayoutable()
+    * @generated
+    */
+   int GLAYOUTABLE = 25;
+
+   /**
+    * The feature id for the '<em><b>Layout Options</b></em>' map.
+    * <!-- begin-user-doc -->
+   	 * <!-- end-user-doc -->
+    * @generated
+    * @ordered
+    */
+   int GLAYOUTABLE__LAYOUT_OPTIONS = 0;
+
+   /**
+    * The number of structural features of the '<em>GLayoutable</em>' class.
+    * <!-- begin-user-doc -->
+   	 * <!-- end-user-doc -->
+    * @generated
+    * @ordered
+    */
+   int GLAYOUTABLE_FEATURE_COUNT = 1;
+
+   /**
+    * The number of operations of the '<em>GLayoutable</em>' class.
+    * <!-- begin-user-doc -->
+   	 * <!-- end-user-doc -->
+    * @generated
+    * @ordered
+    */
+   int GLAYOUTABLE_OPERATION_COUNT = 0;
+
+   /**
     * The meta object id for the '{@link org.eclipse.glsp.graph.GLayouting <em>GLayouting</em>}' class.
     * <!-- begin-user-doc -->
     * <!-- end-user-doc -->
@@ -1729,22 +1811,22 @@ public interface GraphPackage extends EPackage {
    int GLAYOUTING = 16;
 
    /**
-    * The feature id for the '<em><b>Layout</b></em>' attribute.
-    * <!-- begin-user-doc -->
-    * <!-- end-user-doc -->
-    * @generated
-    * @ordered
-    */
-   int GLAYOUTING__LAYOUT = 0;
-
-   /**
     * The feature id for the '<em><b>Layout Options</b></em>' map.
     * <!-- begin-user-doc -->
     * <!-- end-user-doc -->
     * @generated
     * @ordered
     */
-   int GLAYOUTING__LAYOUT_OPTIONS = 1;
+   int GLAYOUTING__LAYOUT_OPTIONS = GLAYOUTABLE__LAYOUT_OPTIONS;
+
+   /**
+    * The feature id for the '<em><b>Layout</b></em>' attribute.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    * @ordered
+    */
+   int GLAYOUTING__LAYOUT = GLAYOUTABLE_FEATURE_COUNT + 0;
 
    /**
     * The number of structural features of the '<em>GLayouting</em>' class.
@@ -1753,7 +1835,7 @@ public interface GraphPackage extends EPackage {
     * @generated
     * @ordered
     */
-   int GLAYOUTING_FEATURE_COUNT = 2;
+   int GLAYOUTING_FEATURE_COUNT = GLAYOUTABLE_FEATURE_COUNT + 1;
 
    /**
     * The number of operations of the '<em>GLayouting</em>' class.
@@ -1762,7 +1844,7 @@ public interface GraphPackage extends EPackage {
     * @generated
     * @ordered
     */
-   int GLAYOUTING_OPERATION_COUNT = 0;
+   int GLAYOUTING_OPERATION_COUNT = GLAYOUTABLE_OPERATION_COUNT + 0;
 
    /**
     * The meta object id for the '{@link org.eclipse.glsp.graph.impl.GBoundsImpl <em>GBounds</em>}' class.
@@ -2103,121 +2185,121 @@ public interface GraphPackage extends EPackage {
    int GSHAPE_PRE_RENDERED_ELEMENT = 23;
 
    /**
-   	 * The feature id for the '<em><b>Args</b></em>' map.
-   	 * <!-- begin-user-doc -->
+    * The feature id for the '<em><b>Args</b></em>' map.
+    * <!-- begin-user-doc -->
    	 * <!-- end-user-doc -->
-   	 * @generated
-   	 * @ordered
-   	 */
+    * @generated
+    * @ordered
+    */
    int GSHAPE_PRE_RENDERED_ELEMENT__ARGS = GPRE_RENDERED_ELEMENT__ARGS;
 
    /**
-   	 * The feature id for the '<em><b>Id</b></em>' attribute.
-   	 * <!-- begin-user-doc -->
+    * The feature id for the '<em><b>Id</b></em>' attribute.
+    * <!-- begin-user-doc -->
    	 * <!-- end-user-doc -->
-   	 * @generated
-   	 * @ordered
-   	 */
+    * @generated
+    * @ordered
+    */
    int GSHAPE_PRE_RENDERED_ELEMENT__ID = GPRE_RENDERED_ELEMENT__ID;
 
    /**
-   	 * The feature id for the '<em><b>Css Classes</b></em>' attribute list.
-   	 * <!-- begin-user-doc -->
+    * The feature id for the '<em><b>Css Classes</b></em>' attribute list.
+    * <!-- begin-user-doc -->
    	 * <!-- end-user-doc -->
-   	 * @generated
-   	 * @ordered
-   	 */
+    * @generated
+    * @ordered
+    */
    int GSHAPE_PRE_RENDERED_ELEMENT__CSS_CLASSES = GPRE_RENDERED_ELEMENT__CSS_CLASSES;
 
    /**
-   	 * The feature id for the '<em><b>Children</b></em>' containment reference list.
-   	 * <!-- begin-user-doc -->
+    * The feature id for the '<em><b>Children</b></em>' containment reference list.
+    * <!-- begin-user-doc -->
    	 * <!-- end-user-doc -->
-   	 * @generated
-   	 * @ordered
-   	 */
+    * @generated
+    * @ordered
+    */
    int GSHAPE_PRE_RENDERED_ELEMENT__CHILDREN = GPRE_RENDERED_ELEMENT__CHILDREN;
 
    /**
-   	 * The feature id for the '<em><b>Parent</b></em>' container reference.
-   	 * <!-- begin-user-doc -->
+    * The feature id for the '<em><b>Parent</b></em>' container reference.
+    * <!-- begin-user-doc -->
    	 * <!-- end-user-doc -->
-   	 * @generated
-   	 * @ordered
-   	 */
+    * @generated
+    * @ordered
+    */
    int GSHAPE_PRE_RENDERED_ELEMENT__PARENT = GPRE_RENDERED_ELEMENT__PARENT;
 
    /**
-   	 * The feature id for the '<em><b>Trace</b></em>' attribute.
-   	 * <!-- begin-user-doc -->
+    * The feature id for the '<em><b>Trace</b></em>' attribute.
+    * <!-- begin-user-doc -->
    	 * <!-- end-user-doc -->
-   	 * @generated
-   	 * @ordered
-   	 */
+    * @generated
+    * @ordered
+    */
    int GSHAPE_PRE_RENDERED_ELEMENT__TRACE = GPRE_RENDERED_ELEMENT__TRACE;
 
    /**
-   	 * The feature id for the '<em><b>Type</b></em>' attribute.
-   	 * <!-- begin-user-doc -->
+    * The feature id for the '<em><b>Type</b></em>' attribute.
+    * <!-- begin-user-doc -->
    	 * <!-- end-user-doc -->
-   	 * @generated
-   	 * @ordered
-   	 */
+    * @generated
+    * @ordered
+    */
    int GSHAPE_PRE_RENDERED_ELEMENT__TYPE = GPRE_RENDERED_ELEMENT__TYPE;
 
    /**
-   	 * The feature id for the '<em><b>Code</b></em>' attribute.
-   	 * <!-- begin-user-doc -->
+    * The feature id for the '<em><b>Code</b></em>' attribute.
+    * <!-- begin-user-doc -->
    	 * <!-- end-user-doc -->
-   	 * @generated
-   	 * @ordered
-   	 */
+    * @generated
+    * @ordered
+    */
    int GSHAPE_PRE_RENDERED_ELEMENT__CODE = GPRE_RENDERED_ELEMENT__CODE;
 
    /**
-   	 * The feature id for the '<em><b>Position</b></em>' containment reference.
-   	 * <!-- begin-user-doc -->
+    * The feature id for the '<em><b>Position</b></em>' containment reference.
+    * <!-- begin-user-doc -->
    	 * <!-- end-user-doc -->
-   	 * @generated
-   	 * @ordered
-   	 */
+    * @generated
+    * @ordered
+    */
    int GSHAPE_PRE_RENDERED_ELEMENT__POSITION = GPRE_RENDERED_ELEMENT_FEATURE_COUNT + 0;
 
    /**
-   	 * The feature id for the '<em><b>Size</b></em>' containment reference.
-   	 * <!-- begin-user-doc -->
+    * The feature id for the '<em><b>Size</b></em>' containment reference.
+    * <!-- begin-user-doc -->
    	 * <!-- end-user-doc -->
-   	 * @generated
-   	 * @ordered
-   	 */
+    * @generated
+    * @ordered
+    */
    int GSHAPE_PRE_RENDERED_ELEMENT__SIZE = GPRE_RENDERED_ELEMENT_FEATURE_COUNT + 1;
 
    /**
-   	 * The number of structural features of the '<em>GShape Pre Rendered Element</em>' class.
-   	 * <!-- begin-user-doc -->
+    * The number of structural features of the '<em>GShape Pre Rendered Element</em>' class.
+    * <!-- begin-user-doc -->
    	 * <!-- end-user-doc -->
-   	 * @generated
-   	 * @ordered
-   	 */
+    * @generated
+    * @ordered
+    */
    int GSHAPE_PRE_RENDERED_ELEMENT_FEATURE_COUNT = GPRE_RENDERED_ELEMENT_FEATURE_COUNT + 2;
 
    /**
-   	 * The number of operations of the '<em>GShape Pre Rendered Element</em>' class.
-   	 * <!-- begin-user-doc -->
+    * The number of operations of the '<em>GShape Pre Rendered Element</em>' class.
+    * <!-- begin-user-doc -->
    	 * <!-- end-user-doc -->
-   	 * @generated
-   	 * @ordered
-   	 */
+    * @generated
+    * @ordered
+    */
    int GSHAPE_PRE_RENDERED_ELEMENT_OPERATION_COUNT = GPRE_RENDERED_ELEMENT_OPERATION_COUNT + 0;
 
    /**
-   	 * The meta object id for the '{@link org.eclipse.glsp.graph.impl.StringToObjectMapEntryImpl <em>String To Object Map Entry</em>}' class.
-   	 * <!-- begin-user-doc -->
+    * The meta object id for the '{@link org.eclipse.glsp.graph.impl.StringToObjectMapEntryImpl <em>String To Object Map Entry</em>}' class.
+    * <!-- begin-user-doc -->
     * <!-- end-user-doc -->
-   	 * @see org.eclipse.glsp.graph.impl.StringToObjectMapEntryImpl
-   	 * @see org.eclipse.glsp.graph.impl.GraphPackageImpl#getStringToObjectMapEntry()
-   	 * @generated
-   	 */
+    * @see org.eclipse.glsp.graph.impl.StringToObjectMapEntryImpl
+    * @see org.eclipse.glsp.graph.impl.GraphPackageImpl#getStringToObjectMapEntry()
+    * @generated
+    */
    int STRING_TO_OBJECT_MAP_ENTRY = 24;
 
    /**
@@ -2264,7 +2346,7 @@ public interface GraphPackage extends EPackage {
     * @see org.eclipse.glsp.graph.impl.GraphPackageImpl#getGSeverity()
     * @generated
     */
-   int GSEVERITY = 25;
+   int GSEVERITY = 26;
 
    /**
     * Returns the meta object for class '{@link org.eclipse.glsp.graph.GModelElement <em>GModel Element</em>}'.
@@ -2361,17 +2443,6 @@ public interface GraphPackage extends EPackage {
     * @generated
     */
    EClass getGGraph();
-
-   /**
-    * Returns the meta object for the map '{@link org.eclipse.glsp.graph.GGraph#getLayoutOptions <em>Layout Options</em>}'.
-    * <!-- begin-user-doc -->
-    * <!-- end-user-doc -->
-    * @return the meta object for the map '<em>Layout Options</em>'.
-    * @see org.eclipse.glsp.graph.GGraph#getLayoutOptions()
-    * @see #getGGraph()
-    * @generated
-    */
-   EReference getGGraph_LayoutOptions();
 
    /**
     * Returns the meta object for class '{@link org.eclipse.glsp.graph.GModelRoot <em>GModel Root</em>}'.
@@ -2767,17 +2838,6 @@ public interface GraphPackage extends EPackage {
    EAttribute getGLayouting_Layout();
 
    /**
-    * Returns the meta object for the map '{@link org.eclipse.glsp.graph.GLayouting#getLayoutOptions <em>Layout Options</em>}'.
-    * <!-- begin-user-doc -->
-    * <!-- end-user-doc -->
-    * @return the meta object for the map '<em>Layout Options</em>'.
-    * @see org.eclipse.glsp.graph.GLayouting#getLayoutOptions()
-    * @see #getGLayouting()
-    * @generated
-    */
-   EReference getGLayouting_LayoutOptions();
-
-   /**
     * Returns the meta object for class '{@link org.eclipse.glsp.graph.GBounds <em>GBounds</em>}'.
     * <!-- begin-user-doc -->
     * <!-- end-user-doc -->
@@ -2958,15 +3018,15 @@ public interface GraphPackage extends EPackage {
    EClass getGShapePreRenderedElement();
 
    /**
-   	 * Returns the meta object for class '{@link java.util.Map.Entry <em>String To Object Map Entry</em>}'.
-   	 * <!-- begin-user-doc -->
+    * Returns the meta object for class '{@link java.util.Map.Entry <em>String To Object Map Entry</em>}'.
+    * <!-- begin-user-doc -->
     * <!-- end-user-doc -->
-   	 * @return the meta object for class '<em>String To Object Map Entry</em>'.
-   	 * @see java.util.Map.Entry
-   	 * @model keyDataType="org.eclipse.emf.ecore.EString" keyRequired="true"
-   	 *        valueDataType="org.eclipse.emf.ecore.EJavaObject"
-   	 * @generated
-   	 */
+    * @return the meta object for class '<em>String To Object Map Entry</em>'.
+    * @see java.util.Map.Entry
+    * @model keyDataType="org.eclipse.emf.ecore.EString" keyRequired="true"
+    *        valueDataType="org.eclipse.emf.ecore.EJavaObject"
+    * @generated
+    */
    EClass getStringToObjectMapEntry();
 
    /**
@@ -2990,6 +3050,27 @@ public interface GraphPackage extends EPackage {
     * @generated
     */
    EAttribute getStringToObjectMapEntry_Value();
+
+   /**
+    * Returns the meta object for class '{@link org.eclipse.glsp.graph.GLayoutable <em>GLayoutable</em>}'.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @return the meta object for class '<em>GLayoutable</em>'.
+    * @see org.eclipse.glsp.graph.GLayoutable
+    * @generated
+    */
+   EClass getGLayoutable();
+
+   /**
+    * Returns the meta object for the map '{@link org.eclipse.glsp.graph.GLayoutable#getLayoutOptions <em>Layout Options</em>}'.
+    * <!-- begin-user-doc -->
+   	 * <!-- end-user-doc -->
+    * @return the meta object for the map '<em>Layout Options</em>'.
+    * @see org.eclipse.glsp.graph.GLayoutable#getLayoutOptions()
+    * @see #getGLayoutable()
+    * @generated
+    */
+   EReference getGLayoutable_LayoutOptions();
 
    /**
     * Returns the meta object for enum '{@link org.eclipse.glsp.graph.GSeverity <em>GSeverity</em>}'.
@@ -3101,14 +3182,6 @@ public interface GraphPackage extends EPackage {
        * @generated
        */
       EClass GGRAPH = eINSTANCE.getGGraph();
-
-      /**
-       * The meta object literal for the '<em><b>Layout Options</b></em>' map feature.
-       * <!-- begin-user-doc -->
-       * <!-- end-user-doc -->
-       * @generated
-       */
-      EReference GGRAPH__LAYOUT_OPTIONS = eINSTANCE.getGGraph_LayoutOptions();
 
       /**
        * The meta object literal for the '{@link org.eclipse.glsp.graph.impl.GModelRootImpl <em>GModel Root</em>}' class.
@@ -3435,14 +3508,6 @@ public interface GraphPackage extends EPackage {
       EAttribute GLAYOUTING__LAYOUT = eINSTANCE.getGLayouting_Layout();
 
       /**
-       * The meta object literal for the '<em><b>Layout Options</b></em>' map feature.
-       * <!-- begin-user-doc -->
-       * <!-- end-user-doc -->
-       * @generated
-       */
-      EReference GLAYOUTING__LAYOUT_OPTIONS = eINSTANCE.getGLayouting_LayoutOptions();
-
-      /**
        * The meta object literal for the '{@link org.eclipse.glsp.graph.impl.GBoundsImpl <em>GBounds</em>}' class.
        * <!-- begin-user-doc -->
        * <!-- end-user-doc -->
@@ -3593,13 +3658,13 @@ public interface GraphPackage extends EPackage {
       EClass GSHAPE_PRE_RENDERED_ELEMENT = eINSTANCE.getGShapePreRenderedElement();
 
       /**
-      	 * The meta object literal for the '{@link org.eclipse.glsp.graph.impl.StringToObjectMapEntryImpl <em>String To Object Map Entry</em>}' class.
-      	 * <!-- begin-user-doc -->
+       * The meta object literal for the '{@link org.eclipse.glsp.graph.impl.StringToObjectMapEntryImpl <em>String To Object Map Entry</em>}' class.
+       * <!-- begin-user-doc -->
        * <!-- end-user-doc -->
-      	 * @see org.eclipse.glsp.graph.impl.StringToObjectMapEntryImpl
-      	 * @see org.eclipse.glsp.graph.impl.GraphPackageImpl#getStringToObjectMapEntry()
-      	 * @generated
-      	 */
+       * @see org.eclipse.glsp.graph.impl.StringToObjectMapEntryImpl
+       * @see org.eclipse.glsp.graph.impl.GraphPackageImpl#getStringToObjectMapEntry()
+       * @generated
+       */
       EClass STRING_TO_OBJECT_MAP_ENTRY = eINSTANCE.getStringToObjectMapEntry();
 
       /**
@@ -3617,6 +3682,24 @@ public interface GraphPackage extends EPackage {
        * @generated
        */
       EAttribute STRING_TO_OBJECT_MAP_ENTRY__VALUE = eINSTANCE.getStringToObjectMapEntry_Value();
+
+      /**
+       * The meta object literal for the '{@link org.eclipse.glsp.graph.impl.GLayoutableImpl <em>GLayoutable</em>}' class.
+       * <!-- begin-user-doc -->
+       * <!-- end-user-doc -->
+       * @see org.eclipse.glsp.graph.impl.GLayoutableImpl
+       * @see org.eclipse.glsp.graph.impl.GraphPackageImpl#getGLayoutable()
+       * @generated
+       */
+      EClass GLAYOUTABLE = eINSTANCE.getGLayoutable();
+
+      /**
+       * The meta object literal for the '<em><b>Layout Options</b></em>' map feature.
+       * <!-- begin-user-doc -->
+      	 * <!-- end-user-doc -->
+       * @generated
+       */
+      EReference GLAYOUTABLE__LAYOUT_OPTIONS = eINSTANCE.getGLayoutable_LayoutOptions();
 
       /**
        * The meta object literal for the '{@link org.eclipse.glsp.graph.GSeverity <em>GSeverity</em>}' enum.

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GButtonImpl.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GButtonImpl.java
@@ -23,19 +23,23 @@ import org.eclipse.emf.common.notify.NotificationChain;
 
 import org.eclipse.emf.common.util.EList;
 
+import org.eclipse.emf.common.util.EMap;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.InternalEObject;
 
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 
 import org.eclipse.emf.ecore.util.EDataTypeUniqueEList;
 import org.eclipse.emf.ecore.util.EObjectContainmentWithInverseEList;
+import org.eclipse.emf.ecore.util.EcoreEMap;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.util.InternalEList;
 
 import org.eclipse.glsp.graph.GBoundsAware;
 import org.eclipse.glsp.graph.GButton;
 import org.eclipse.glsp.graph.GDimension;
+import org.eclipse.glsp.graph.GLayoutable;
 import org.eclipse.glsp.graph.GModelElement;
 import org.eclipse.glsp.graph.GPoint;
 import org.eclipse.glsp.graph.GraphPackage;
@@ -56,6 +60,7 @@ import org.eclipse.glsp.graph.GraphPackage;
  *   <li>{@link org.eclipse.glsp.graph.impl.GButtonImpl#getType <em>Type</em>}</li>
  *   <li>{@link org.eclipse.glsp.graph.impl.GButtonImpl#getPosition <em>Position</em>}</li>
  *   <li>{@link org.eclipse.glsp.graph.impl.GButtonImpl#getSize <em>Size</em>}</li>
+ *   <li>{@link org.eclipse.glsp.graph.impl.GButtonImpl#getLayoutOptions <em>Layout Options</em>}</li>
  *   <li>{@link org.eclipse.glsp.graph.impl.GButtonImpl#isEnabled <em>Enabled</em>}</li>
  * </ul>
  *
@@ -161,6 +166,16 @@ public class GButtonImpl extends GArgumentableImpl implements GButton {
     * @ordered
     */
    protected GDimension size;
+
+   /**
+    * The cached value of the '{@link #getLayoutOptions() <em>Layout Options</em>}' map.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @see #getLayoutOptions()
+    * @generated
+    * @ordered
+    */
+   protected EMap<String, Object> layoutOptions;
 
    /**
     * The default value of the '{@link #isEnabled() <em>Enabled</em>}' attribute.
@@ -442,6 +457,20 @@ public class GButtonImpl extends GArgumentableImpl implements GButton {
     * @generated
     */
    @Override
+   public EMap<String, Object> getLayoutOptions() {
+      if (layoutOptions == null) {
+         layoutOptions = new EcoreEMap<String, Object>(GraphPackage.Literals.STRING_TO_OBJECT_MAP_ENTRY,
+            StringToObjectMapEntryImpl.class, this, GraphPackage.GBUTTON__LAYOUT_OPTIONS);
+      }
+      return layoutOptions;
+   }
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   @Override
    public boolean isEnabled() { return enabled; }
 
    /**
@@ -492,6 +521,8 @@ public class GButtonImpl extends GArgumentableImpl implements GButton {
             return basicSetPosition(null, msgs);
          case GraphPackage.GBUTTON__SIZE:
             return basicSetSize(null, msgs);
+         case GraphPackage.GBUTTON__LAYOUT_OPTIONS:
+            return ((InternalEList<?>) getLayoutOptions()).basicRemove(otherEnd, msgs);
       }
       return super.eInverseRemove(otherEnd, featureID, msgs);
    }
@@ -535,6 +566,11 @@ public class GButtonImpl extends GArgumentableImpl implements GButton {
             return getPosition();
          case GraphPackage.GBUTTON__SIZE:
             return getSize();
+         case GraphPackage.GBUTTON__LAYOUT_OPTIONS:
+            if (coreType)
+               return getLayoutOptions();
+            else
+               return getLayoutOptions().map();
          case GraphPackage.GBUTTON__ENABLED:
             return isEnabled();
       }
@@ -576,6 +612,9 @@ public class GButtonImpl extends GArgumentableImpl implements GButton {
          case GraphPackage.GBUTTON__SIZE:
             setSize((GDimension) newValue);
             return;
+         case GraphPackage.GBUTTON__LAYOUT_OPTIONS:
+            ((EStructuralFeature.Setting) getLayoutOptions()).set(newValue);
+            return;
          case GraphPackage.GBUTTON__ENABLED:
             setEnabled((Boolean) newValue);
             return;
@@ -615,6 +654,9 @@ public class GButtonImpl extends GArgumentableImpl implements GButton {
          case GraphPackage.GBUTTON__SIZE:
             setSize((GDimension) null);
             return;
+         case GraphPackage.GBUTTON__LAYOUT_OPTIONS:
+            getLayoutOptions().clear();
+            return;
          case GraphPackage.GBUTTON__ENABLED:
             setEnabled(ENABLED_EDEFAULT);
             return;
@@ -646,6 +688,8 @@ public class GButtonImpl extends GArgumentableImpl implements GButton {
             return position != null;
          case GraphPackage.GBUTTON__SIZE:
             return size != null;
+         case GraphPackage.GBUTTON__LAYOUT_OPTIONS:
+            return layoutOptions != null && !layoutOptions.isEmpty();
          case GraphPackage.GBUTTON__ENABLED:
             return enabled != ENABLED_EDEFAULT;
       }
@@ -669,6 +713,14 @@ public class GButtonImpl extends GArgumentableImpl implements GButton {
                return -1;
          }
       }
+      if (baseClass == GLayoutable.class) {
+         switch (derivedFeatureID) {
+            case GraphPackage.GBUTTON__LAYOUT_OPTIONS:
+               return GraphPackage.GLAYOUTABLE__LAYOUT_OPTIONS;
+            default:
+               return -1;
+         }
+      }
       return super.eBaseStructuralFeatureID(derivedFeatureID, baseClass);
    }
 
@@ -685,6 +737,14 @@ public class GButtonImpl extends GArgumentableImpl implements GButton {
                return GraphPackage.GBUTTON__POSITION;
             case GraphPackage.GBOUNDS_AWARE__SIZE:
                return GraphPackage.GBUTTON__SIZE;
+            default:
+               return -1;
+         }
+      }
+      if (baseClass == GLayoutable.class) {
+         switch (baseFeatureID) {
+            case GraphPackage.GLAYOUTABLE__LAYOUT_OPTIONS:
+               return GraphPackage.GBUTTON__LAYOUT_OPTIONS;
             default:
                return -1;
          }

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GCompartmentImpl.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GCompartmentImpl.java
@@ -39,6 +39,7 @@ import org.eclipse.emf.ecore.util.InternalEList;
 import org.eclipse.glsp.graph.GBoundsAware;
 import org.eclipse.glsp.graph.GCompartment;
 import org.eclipse.glsp.graph.GDimension;
+import org.eclipse.glsp.graph.GLayoutable;
 import org.eclipse.glsp.graph.GLayouting;
 import org.eclipse.glsp.graph.GModelElement;
 import org.eclipse.glsp.graph.GPoint;
@@ -60,8 +61,8 @@ import org.eclipse.glsp.graph.GraphPackage;
  *   <li>{@link org.eclipse.glsp.graph.impl.GCompartmentImpl#getType <em>Type</em>}</li>
  *   <li>{@link org.eclipse.glsp.graph.impl.GCompartmentImpl#getPosition <em>Position</em>}</li>
  *   <li>{@link org.eclipse.glsp.graph.impl.GCompartmentImpl#getSize <em>Size</em>}</li>
- *   <li>{@link org.eclipse.glsp.graph.impl.GCompartmentImpl#getLayout <em>Layout</em>}</li>
  *   <li>{@link org.eclipse.glsp.graph.impl.GCompartmentImpl#getLayoutOptions <em>Layout Options</em>}</li>
+ *   <li>{@link org.eclipse.glsp.graph.impl.GCompartmentImpl#getLayout <em>Layout</em>}</li>
  * </ul>
  *
  * @generated
@@ -168,6 +169,16 @@ public class GCompartmentImpl extends GArgumentableImpl implements GCompartment 
    protected GDimension size;
 
    /**
+    * The cached value of the '{@link #getLayoutOptions() <em>Layout Options</em>}' map.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @see #getLayoutOptions()
+    * @generated
+    * @ordered
+    */
+   protected EMap<String, Object> layoutOptions;
+
+   /**
     * The default value of the '{@link #getLayout() <em>Layout</em>}' attribute.
     * <!-- begin-user-doc -->
     * <!-- end-user-doc -->
@@ -186,16 +197,6 @@ public class GCompartmentImpl extends GArgumentableImpl implements GCompartment 
     * @ordered
     */
    protected String layout = LAYOUT_EDEFAULT;
-
-   /**
-    * The cached value of the '{@link #getLayoutOptions() <em>Layout Options</em>}' map.
-    * <!-- begin-user-doc -->
-    * <!-- end-user-doc -->
-    * @see #getLayoutOptions()
-    * @generated
-    * @ordered
-    */
-   protected EMap<String, Object> layoutOptions;
 
    /**
     * <!-- begin-user-doc -->
@@ -567,13 +568,13 @@ public class GCompartmentImpl extends GArgumentableImpl implements GCompartment 
             return getPosition();
          case GraphPackage.GCOMPARTMENT__SIZE:
             return getSize();
-         case GraphPackage.GCOMPARTMENT__LAYOUT:
-            return getLayout();
          case GraphPackage.GCOMPARTMENT__LAYOUT_OPTIONS:
             if (coreType)
                return getLayoutOptions();
             else
                return getLayoutOptions().map();
+         case GraphPackage.GCOMPARTMENT__LAYOUT:
+            return getLayout();
       }
       return super.eGet(featureID, resolve, coreType);
    }
@@ -613,11 +614,11 @@ public class GCompartmentImpl extends GArgumentableImpl implements GCompartment 
          case GraphPackage.GCOMPARTMENT__SIZE:
             setSize((GDimension) newValue);
             return;
-         case GraphPackage.GCOMPARTMENT__LAYOUT:
-            setLayout((String) newValue);
-            return;
          case GraphPackage.GCOMPARTMENT__LAYOUT_OPTIONS:
             ((EStructuralFeature.Setting) getLayoutOptions()).set(newValue);
+            return;
+         case GraphPackage.GCOMPARTMENT__LAYOUT:
+            setLayout((String) newValue);
             return;
       }
       super.eSet(featureID, newValue);
@@ -655,11 +656,11 @@ public class GCompartmentImpl extends GArgumentableImpl implements GCompartment 
          case GraphPackage.GCOMPARTMENT__SIZE:
             setSize((GDimension) null);
             return;
-         case GraphPackage.GCOMPARTMENT__LAYOUT:
-            setLayout(LAYOUT_EDEFAULT);
-            return;
          case GraphPackage.GCOMPARTMENT__LAYOUT_OPTIONS:
             getLayoutOptions().clear();
+            return;
+         case GraphPackage.GCOMPARTMENT__LAYOUT:
+            setLayout(LAYOUT_EDEFAULT);
             return;
       }
       super.eUnset(featureID);
@@ -689,10 +690,10 @@ public class GCompartmentImpl extends GArgumentableImpl implements GCompartment 
             return position != null;
          case GraphPackage.GCOMPARTMENT__SIZE:
             return size != null;
-         case GraphPackage.GCOMPARTMENT__LAYOUT:
-            return LAYOUT_EDEFAULT == null ? layout != null : !LAYOUT_EDEFAULT.equals(layout);
          case GraphPackage.GCOMPARTMENT__LAYOUT_OPTIONS:
             return layoutOptions != null && !layoutOptions.isEmpty();
+         case GraphPackage.GCOMPARTMENT__LAYOUT:
+            return LAYOUT_EDEFAULT == null ? layout != null : !LAYOUT_EDEFAULT.equals(layout);
       }
       return super.eIsSet(featureID);
    }
@@ -714,12 +715,18 @@ public class GCompartmentImpl extends GArgumentableImpl implements GCompartment 
                return -1;
          }
       }
+      if (baseClass == GLayoutable.class) {
+         switch (derivedFeatureID) {
+            case GraphPackage.GCOMPARTMENT__LAYOUT_OPTIONS:
+               return GraphPackage.GLAYOUTABLE__LAYOUT_OPTIONS;
+            default:
+               return -1;
+         }
+      }
       if (baseClass == GLayouting.class) {
          switch (derivedFeatureID) {
             case GraphPackage.GCOMPARTMENT__LAYOUT:
                return GraphPackage.GLAYOUTING__LAYOUT;
-            case GraphPackage.GCOMPARTMENT__LAYOUT_OPTIONS:
-               return GraphPackage.GLAYOUTING__LAYOUT_OPTIONS;
             default:
                return -1;
          }
@@ -744,12 +751,18 @@ public class GCompartmentImpl extends GArgumentableImpl implements GCompartment 
                return -1;
          }
       }
+      if (baseClass == GLayoutable.class) {
+         switch (baseFeatureID) {
+            case GraphPackage.GLAYOUTABLE__LAYOUT_OPTIONS:
+               return GraphPackage.GCOMPARTMENT__LAYOUT_OPTIONS;
+            default:
+               return -1;
+         }
+      }
       if (baseClass == GLayouting.class) {
          switch (baseFeatureID) {
             case GraphPackage.GLAYOUTING__LAYOUT:
                return GraphPackage.GCOMPARTMENT__LAYOUT;
-            case GraphPackage.GLAYOUTING__LAYOUT_OPTIONS:
-               return GraphPackage.GCOMPARTMENT__LAYOUT_OPTIONS;
             default:
                return -1;
          }

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GGraphImpl.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GGraphImpl.java
@@ -33,6 +33,7 @@ import org.eclipse.emf.ecore.util.InternalEList;
 import org.eclipse.glsp.graph.GBoundsAware;
 import org.eclipse.glsp.graph.GDimension;
 import org.eclipse.glsp.graph.GGraph;
+import org.eclipse.glsp.graph.GLayoutable;
 import org.eclipse.glsp.graph.GPoint;
 import org.eclipse.glsp.graph.GraphPackage;
 
@@ -330,6 +331,14 @@ public class GGraphImpl extends GModelRootImpl implements GGraph {
                return -1;
          }
       }
+      if (baseClass == GLayoutable.class) {
+         switch (derivedFeatureID) {
+            case GraphPackage.GGRAPH__LAYOUT_OPTIONS:
+               return GraphPackage.GLAYOUTABLE__LAYOUT_OPTIONS;
+            default:
+               return -1;
+         }
+      }
       return super.eBaseStructuralFeatureID(derivedFeatureID, baseClass);
    }
 
@@ -346,6 +355,14 @@ public class GGraphImpl extends GModelRootImpl implements GGraph {
                return GraphPackage.GGRAPH__POSITION;
             case GraphPackage.GBOUNDS_AWARE__SIZE:
                return GraphPackage.GGRAPH__SIZE;
+            default:
+               return -1;
+         }
+      }
+      if (baseClass == GLayoutable.class) {
+         switch (baseFeatureID) {
+            case GraphPackage.GLAYOUTABLE__LAYOUT_OPTIONS:
+               return GraphPackage.GGRAPH__LAYOUT_OPTIONS;
             default:
                return -1;
          }

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GIssueMarkerImpl.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GIssueMarkerImpl.java
@@ -23,7 +23,9 @@ import org.eclipse.emf.common.notify.NotificationChain;
 
 import org.eclipse.emf.common.util.EList;
 
+import org.eclipse.emf.common.util.EMap;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.InternalEObject;
 
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
@@ -31,6 +33,7 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.util.EDataTypeUniqueEList;
 import org.eclipse.emf.ecore.util.EObjectContainmentEList;
 import org.eclipse.emf.ecore.util.EObjectContainmentWithInverseEList;
+import org.eclipse.emf.ecore.util.EcoreEMap;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.util.InternalEList;
 
@@ -38,6 +41,7 @@ import org.eclipse.glsp.graph.GBoundsAware;
 import org.eclipse.glsp.graph.GDimension;
 import org.eclipse.glsp.graph.GIssue;
 import org.eclipse.glsp.graph.GIssueMarker;
+import org.eclipse.glsp.graph.GLayoutable;
 import org.eclipse.glsp.graph.GModelElement;
 import org.eclipse.glsp.graph.GPoint;
 import org.eclipse.glsp.graph.GraphPackage;
@@ -58,6 +62,7 @@ import org.eclipse.glsp.graph.GraphPackage;
  *   <li>{@link org.eclipse.glsp.graph.impl.GIssueMarkerImpl#getType <em>Type</em>}</li>
  *   <li>{@link org.eclipse.glsp.graph.impl.GIssueMarkerImpl#getPosition <em>Position</em>}</li>
  *   <li>{@link org.eclipse.glsp.graph.impl.GIssueMarkerImpl#getSize <em>Size</em>}</li>
+ *   <li>{@link org.eclipse.glsp.graph.impl.GIssueMarkerImpl#getLayoutOptions <em>Layout Options</em>}</li>
  *   <li>{@link org.eclipse.glsp.graph.impl.GIssueMarkerImpl#getIssues <em>Issues</em>}</li>
  * </ul>
  *
@@ -163,6 +168,16 @@ public class GIssueMarkerImpl extends GArgumentableImpl implements GIssueMarker 
     * @ordered
     */
    protected GDimension size;
+
+   /**
+    * The cached value of the '{@link #getLayoutOptions() <em>Layout Options</em>}' map.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @see #getLayoutOptions()
+    * @generated
+    * @ordered
+    */
+   protected EMap<String, Object> layoutOptions;
 
    /**
     * The cached value of the '{@link #getIssues() <em>Issues</em>}' containment reference list.
@@ -435,6 +450,20 @@ public class GIssueMarkerImpl extends GArgumentableImpl implements GIssueMarker 
     * @generated
     */
    @Override
+   public EMap<String, Object> getLayoutOptions() {
+      if (layoutOptions == null) {
+         layoutOptions = new EcoreEMap<String, Object>(GraphPackage.Literals.STRING_TO_OBJECT_MAP_ENTRY,
+            StringToObjectMapEntryImpl.class, this, GraphPackage.GISSUE_MARKER__LAYOUT_OPTIONS);
+      }
+      return layoutOptions;
+   }
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   @Override
    public EList<GIssue> getIssues() {
       if (issues == null) {
          issues = new EObjectContainmentEList<GIssue>(GIssue.class, this, GraphPackage.GISSUE_MARKER__ISSUES);
@@ -477,6 +506,8 @@ public class GIssueMarkerImpl extends GArgumentableImpl implements GIssueMarker 
             return basicSetPosition(null, msgs);
          case GraphPackage.GISSUE_MARKER__SIZE:
             return basicSetSize(null, msgs);
+         case GraphPackage.GISSUE_MARKER__LAYOUT_OPTIONS:
+            return ((InternalEList<?>) getLayoutOptions()).basicRemove(otherEnd, msgs);
          case GraphPackage.GISSUE_MARKER__ISSUES:
             return ((InternalEList<?>) getIssues()).basicRemove(otherEnd, msgs);
       }
@@ -522,6 +553,11 @@ public class GIssueMarkerImpl extends GArgumentableImpl implements GIssueMarker 
             return getPosition();
          case GraphPackage.GISSUE_MARKER__SIZE:
             return getSize();
+         case GraphPackage.GISSUE_MARKER__LAYOUT_OPTIONS:
+            if (coreType)
+               return getLayoutOptions();
+            else
+               return getLayoutOptions().map();
          case GraphPackage.GISSUE_MARKER__ISSUES:
             return getIssues();
       }
@@ -563,6 +599,9 @@ public class GIssueMarkerImpl extends GArgumentableImpl implements GIssueMarker 
          case GraphPackage.GISSUE_MARKER__SIZE:
             setSize((GDimension) newValue);
             return;
+         case GraphPackage.GISSUE_MARKER__LAYOUT_OPTIONS:
+            ((EStructuralFeature.Setting) getLayoutOptions()).set(newValue);
+            return;
          case GraphPackage.GISSUE_MARKER__ISSUES:
             getIssues().clear();
             getIssues().addAll((Collection<? extends GIssue>) newValue);
@@ -603,6 +642,9 @@ public class GIssueMarkerImpl extends GArgumentableImpl implements GIssueMarker 
          case GraphPackage.GISSUE_MARKER__SIZE:
             setSize((GDimension) null);
             return;
+         case GraphPackage.GISSUE_MARKER__LAYOUT_OPTIONS:
+            getLayoutOptions().clear();
+            return;
          case GraphPackage.GISSUE_MARKER__ISSUES:
             getIssues().clear();
             return;
@@ -634,6 +676,8 @@ public class GIssueMarkerImpl extends GArgumentableImpl implements GIssueMarker 
             return position != null;
          case GraphPackage.GISSUE_MARKER__SIZE:
             return size != null;
+         case GraphPackage.GISSUE_MARKER__LAYOUT_OPTIONS:
+            return layoutOptions != null && !layoutOptions.isEmpty();
          case GraphPackage.GISSUE_MARKER__ISSUES:
             return issues != null && !issues.isEmpty();
       }
@@ -657,6 +701,14 @@ public class GIssueMarkerImpl extends GArgumentableImpl implements GIssueMarker 
                return -1;
          }
       }
+      if (baseClass == GLayoutable.class) {
+         switch (derivedFeatureID) {
+            case GraphPackage.GISSUE_MARKER__LAYOUT_OPTIONS:
+               return GraphPackage.GLAYOUTABLE__LAYOUT_OPTIONS;
+            default:
+               return -1;
+         }
+      }
       return super.eBaseStructuralFeatureID(derivedFeatureID, baseClass);
    }
 
@@ -673,6 +725,14 @@ public class GIssueMarkerImpl extends GArgumentableImpl implements GIssueMarker 
                return GraphPackage.GISSUE_MARKER__POSITION;
             case GraphPackage.GBOUNDS_AWARE__SIZE:
                return GraphPackage.GISSUE_MARKER__SIZE;
+            default:
+               return -1;
+         }
+      }
+      if (baseClass == GLayoutable.class) {
+         switch (baseFeatureID) {
+            case GraphPackage.GLAYOUTABLE__LAYOUT_OPTIONS:
+               return GraphPackage.GISSUE_MARKER__LAYOUT_OPTIONS;
             default:
                return -1;
          }

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GLabelImpl.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GLabelImpl.java
@@ -42,6 +42,7 @@ import org.eclipse.glsp.graph.GDimension;
 import org.eclipse.glsp.graph.GEdgeLayoutable;
 import org.eclipse.glsp.graph.GEdgePlacement;
 import org.eclipse.glsp.graph.GLabel;
+import org.eclipse.glsp.graph.GLayoutable;
 import org.eclipse.glsp.graph.GModelElement;
 import org.eclipse.glsp.graph.GPoint;
 import org.eclipse.glsp.graph.GShapeElement;
@@ -65,6 +66,7 @@ import org.eclipse.glsp.graph.GraphPackage;
  *   <li>{@link org.eclipse.glsp.graph.impl.GLabelImpl#getType <em>Type</em>}</li>
  *   <li>{@link org.eclipse.glsp.graph.impl.GLabelImpl#getPosition <em>Position</em>}</li>
  *   <li>{@link org.eclipse.glsp.graph.impl.GLabelImpl#getSize <em>Size</em>}</li>
+ *   <li>{@link org.eclipse.glsp.graph.impl.GLabelImpl#getLayoutOptions <em>Layout Options</em>}</li>
  *   <li>{@link org.eclipse.glsp.graph.impl.GLabelImpl#getText <em>Text</em>}</li>
  * </ul>
  *
@@ -190,6 +192,16 @@ public class GLabelImpl extends GAlignableImpl implements GLabel {
     * @ordered
     */
    protected GDimension size;
+
+   /**
+    * The cached value of the '{@link #getLayoutOptions() <em>Layout Options</em>}' map.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @see #getLayoutOptions()
+    * @generated
+    * @ordered
+    */
+   protected EMap<String, Object> layoutOptions;
 
    /**
     * The default value of the '{@link #getText() <em>Text</em>}' attribute.
@@ -535,6 +547,20 @@ public class GLabelImpl extends GAlignableImpl implements GLabel {
     * @generated
     */
    @Override
+   public EMap<String, Object> getLayoutOptions() {
+      if (layoutOptions == null) {
+         layoutOptions = new EcoreEMap<String, Object>(GraphPackage.Literals.STRING_TO_OBJECT_MAP_ENTRY,
+            StringToObjectMapEntryImpl.class, this, GraphPackage.GLABEL__LAYOUT_OPTIONS);
+      }
+      return layoutOptions;
+   }
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   @Override
    public String getText() { return text; }
 
    /**
@@ -589,6 +615,8 @@ public class GLabelImpl extends GAlignableImpl implements GLabel {
             return basicSetPosition(null, msgs);
          case GraphPackage.GLABEL__SIZE:
             return basicSetSize(null, msgs);
+         case GraphPackage.GLABEL__LAYOUT_OPTIONS:
+            return ((InternalEList<?>) getLayoutOptions()).basicRemove(otherEnd, msgs);
       }
       return super.eInverseRemove(otherEnd, featureID, msgs);
    }
@@ -639,6 +667,11 @@ public class GLabelImpl extends GAlignableImpl implements GLabel {
             return getPosition();
          case GraphPackage.GLABEL__SIZE:
             return getSize();
+         case GraphPackage.GLABEL__LAYOUT_OPTIONS:
+            if (coreType)
+               return getLayoutOptions();
+            else
+               return getLayoutOptions().map();
          case GraphPackage.GLABEL__TEXT:
             return getText();
       }
@@ -686,6 +719,9 @@ public class GLabelImpl extends GAlignableImpl implements GLabel {
          case GraphPackage.GLABEL__SIZE:
             setSize((GDimension) newValue);
             return;
+         case GraphPackage.GLABEL__LAYOUT_OPTIONS:
+            ((EStructuralFeature.Setting) getLayoutOptions()).set(newValue);
+            return;
          case GraphPackage.GLABEL__TEXT:
             setText((String) newValue);
             return;
@@ -731,6 +767,9 @@ public class GLabelImpl extends GAlignableImpl implements GLabel {
          case GraphPackage.GLABEL__SIZE:
             setSize((GDimension) null);
             return;
+         case GraphPackage.GLABEL__LAYOUT_OPTIONS:
+            getLayoutOptions().clear();
+            return;
          case GraphPackage.GLABEL__TEXT:
             setText(TEXT_EDEFAULT);
             return;
@@ -766,6 +805,8 @@ public class GLabelImpl extends GAlignableImpl implements GLabel {
             return position != null;
          case GraphPackage.GLABEL__SIZE:
             return size != null;
+         case GraphPackage.GLABEL__LAYOUT_OPTIONS:
+            return layoutOptions != null && !layoutOptions.isEmpty();
          case GraphPackage.GLABEL__TEXT:
             return TEXT_EDEFAULT == null ? text != null : !TEXT_EDEFAULT.equals(text);
       }
@@ -819,6 +860,14 @@ public class GLabelImpl extends GAlignableImpl implements GLabel {
                return GraphPackage.GBOUNDS_AWARE__POSITION;
             case GraphPackage.GLABEL__SIZE:
                return GraphPackage.GBOUNDS_AWARE__SIZE;
+            default:
+               return -1;
+         }
+      }
+      if (baseClass == GLayoutable.class) {
+         switch (derivedFeatureID) {
+            case GraphPackage.GLABEL__LAYOUT_OPTIONS:
+               return GraphPackage.GLAYOUTABLE__LAYOUT_OPTIONS;
             default:
                return -1;
          }
@@ -879,6 +928,14 @@ public class GLabelImpl extends GAlignableImpl implements GLabel {
                return GraphPackage.GLABEL__POSITION;
             case GraphPackage.GBOUNDS_AWARE__SIZE:
                return GraphPackage.GLABEL__SIZE;
+            default:
+               return -1;
+         }
+      }
+      if (baseClass == GLayoutable.class) {
+         switch (baseFeatureID) {
+            case GraphPackage.GLAYOUTABLE__LAYOUT_OPTIONS:
+               return GraphPackage.GLABEL__LAYOUT_OPTIONS;
             default:
                return -1;
          }

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GLayoutableImpl.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GLayoutableImpl.java
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) 2019-2022 EclipseSource and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * ********************************************************************************
+ */
+package org.eclipse.glsp.graph.impl;
+
+import org.eclipse.emf.common.notify.NotificationChain;
+
+import org.eclipse.emf.common.util.EMap;
+
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.InternalEObject;
+
+import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
+
+import org.eclipse.emf.ecore.util.EcoreEMap;
+import org.eclipse.emf.ecore.util.InternalEList;
+
+import org.eclipse.glsp.graph.GLayoutable;
+import org.eclipse.glsp.graph.GraphPackage;
+
+/**
+ * <!-- begin-user-doc -->
+ * An implementation of the model object '<em><b>GLayoutable</b></em>'.
+ * <!-- end-user-doc -->
+ * <p>
+ * The following features are implemented:
+ * </p>
+ * <ul>
+ *   <li>{@link org.eclipse.glsp.graph.impl.GLayoutableImpl#getLayoutOptions <em>Layout Options</em>}</li>
+ * </ul>
+ *
+ * @generated
+ */
+public class GLayoutableImpl extends MinimalEObjectImpl.Container implements GLayoutable {
+   /**
+    * The cached value of the '{@link #getLayoutOptions() <em>Layout Options</em>}' map.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @see #getLayoutOptions()
+    * @generated
+    * @ordered
+    */
+   protected EMap<String, Object> layoutOptions;
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   public GLayoutableImpl() {
+      super();
+   }
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   @Override
+   protected EClass eStaticClass() {
+      return GraphPackage.Literals.GLAYOUTABLE;
+   }
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   @Override
+   public EMap<String, Object> getLayoutOptions() {
+      if (layoutOptions == null) {
+         layoutOptions = new EcoreEMap<String, Object>(GraphPackage.Literals.STRING_TO_OBJECT_MAP_ENTRY,
+            StringToObjectMapEntryImpl.class, this, GraphPackage.GLAYOUTABLE__LAYOUT_OPTIONS);
+      }
+      return layoutOptions;
+   }
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   @Override
+   public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
+      switch (featureID) {
+         case GraphPackage.GLAYOUTABLE__LAYOUT_OPTIONS:
+            return ((InternalEList<?>) getLayoutOptions()).basicRemove(otherEnd, msgs);
+      }
+      return super.eInverseRemove(otherEnd, featureID, msgs);
+   }
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   @Override
+   public Object eGet(int featureID, boolean resolve, boolean coreType) {
+      switch (featureID) {
+         case GraphPackage.GLAYOUTABLE__LAYOUT_OPTIONS:
+            if (coreType)
+               return getLayoutOptions();
+            else
+               return getLayoutOptions().map();
+      }
+      return super.eGet(featureID, resolve, coreType);
+   }
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   @Override
+   public void eSet(int featureID, Object newValue) {
+      switch (featureID) {
+         case GraphPackage.GLAYOUTABLE__LAYOUT_OPTIONS:
+            ((EStructuralFeature.Setting) getLayoutOptions()).set(newValue);
+            return;
+      }
+      super.eSet(featureID, newValue);
+   }
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   @Override
+   public void eUnset(int featureID) {
+      switch (featureID) {
+         case GraphPackage.GLAYOUTABLE__LAYOUT_OPTIONS:
+            getLayoutOptions().clear();
+            return;
+      }
+      super.eUnset(featureID);
+   }
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   @Override
+   public boolean eIsSet(int featureID) {
+      switch (featureID) {
+         case GraphPackage.GLAYOUTABLE__LAYOUT_OPTIONS:
+            return layoutOptions != null && !layoutOptions.isEmpty();
+      }
+      return super.eIsSet(featureID);
+   }
+
+} //GLayoutableImpl

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GNodeImpl.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GNodeImpl.java
@@ -40,6 +40,7 @@ import org.eclipse.glsp.graph.GBoundsAware;
 import org.eclipse.glsp.graph.GDimension;
 import org.eclipse.glsp.graph.GEdgeLayoutable;
 import org.eclipse.glsp.graph.GEdgePlacement;
+import org.eclipse.glsp.graph.GLayoutable;
 import org.eclipse.glsp.graph.GLayouting;
 import org.eclipse.glsp.graph.GModelElement;
 import org.eclipse.glsp.graph.GNode;
@@ -62,9 +63,9 @@ import org.eclipse.glsp.graph.GraphPackage;
  *   <li>{@link org.eclipse.glsp.graph.impl.GNodeImpl#getType <em>Type</em>}</li>
  *   <li>{@link org.eclipse.glsp.graph.impl.GNodeImpl#getPosition <em>Position</em>}</li>
  *   <li>{@link org.eclipse.glsp.graph.impl.GNodeImpl#getSize <em>Size</em>}</li>
+ *   <li>{@link org.eclipse.glsp.graph.impl.GNodeImpl#getLayoutOptions <em>Layout Options</em>}</li>
  *   <li>{@link org.eclipse.glsp.graph.impl.GNodeImpl#getEdgePlacement <em>Edge Placement</em>}</li>
  *   <li>{@link org.eclipse.glsp.graph.impl.GNodeImpl#getLayout <em>Layout</em>}</li>
- *   <li>{@link org.eclipse.glsp.graph.impl.GNodeImpl#getLayoutOptions <em>Layout Options</em>}</li>
  * </ul>
  *
  * @generated
@@ -171,6 +172,16 @@ public class GNodeImpl extends GArgumentableImpl implements GNode {
    protected GDimension size;
 
    /**
+    * The cached value of the '{@link #getLayoutOptions() <em>Layout Options</em>}' map.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @see #getLayoutOptions()
+    * @generated
+    * @ordered
+    */
+   protected EMap<String, Object> layoutOptions;
+
+   /**
     * The cached value of the '{@link #getEdgePlacement() <em>Edge Placement</em>}' containment reference.
     * <!-- begin-user-doc -->
     * <!-- end-user-doc -->
@@ -199,16 +210,6 @@ public class GNodeImpl extends GArgumentableImpl implements GNode {
     * @ordered
     */
    protected String layout = LAYOUT_EDEFAULT;
-
-   /**
-    * The cached value of the '{@link #getLayoutOptions() <em>Layout Options</em>}' map.
-    * <!-- begin-user-doc -->
-    * <!-- end-user-doc -->
-    * @see #getLayoutOptions()
-    * @generated
-    * @ordered
-    */
-   protected EMap<String, Object> layoutOptions;
 
    /**
     * <!-- begin-user-doc -->
@@ -583,10 +584,10 @@ public class GNodeImpl extends GArgumentableImpl implements GNode {
             return basicSetPosition(null, msgs);
          case GraphPackage.GNODE__SIZE:
             return basicSetSize(null, msgs);
-         case GraphPackage.GNODE__EDGE_PLACEMENT:
-            return basicSetEdgePlacement(null, msgs);
          case GraphPackage.GNODE__LAYOUT_OPTIONS:
             return ((InternalEList<?>) getLayoutOptions()).basicRemove(otherEnd, msgs);
+         case GraphPackage.GNODE__EDGE_PLACEMENT:
+            return basicSetEdgePlacement(null, msgs);
       }
       return super.eInverseRemove(otherEnd, featureID, msgs);
    }
@@ -630,15 +631,15 @@ public class GNodeImpl extends GArgumentableImpl implements GNode {
             return getPosition();
          case GraphPackage.GNODE__SIZE:
             return getSize();
-         case GraphPackage.GNODE__EDGE_PLACEMENT:
-            return getEdgePlacement();
-         case GraphPackage.GNODE__LAYOUT:
-            return getLayout();
          case GraphPackage.GNODE__LAYOUT_OPTIONS:
             if (coreType)
                return getLayoutOptions();
             else
                return getLayoutOptions().map();
+         case GraphPackage.GNODE__EDGE_PLACEMENT:
+            return getEdgePlacement();
+         case GraphPackage.GNODE__LAYOUT:
+            return getLayout();
       }
       return super.eGet(featureID, resolve, coreType);
    }
@@ -678,14 +679,14 @@ public class GNodeImpl extends GArgumentableImpl implements GNode {
          case GraphPackage.GNODE__SIZE:
             setSize((GDimension) newValue);
             return;
+         case GraphPackage.GNODE__LAYOUT_OPTIONS:
+            ((EStructuralFeature.Setting) getLayoutOptions()).set(newValue);
+            return;
          case GraphPackage.GNODE__EDGE_PLACEMENT:
             setEdgePlacement((GEdgePlacement) newValue);
             return;
          case GraphPackage.GNODE__LAYOUT:
             setLayout((String) newValue);
-            return;
-         case GraphPackage.GNODE__LAYOUT_OPTIONS:
-            ((EStructuralFeature.Setting) getLayoutOptions()).set(newValue);
             return;
       }
       super.eSet(featureID, newValue);
@@ -723,14 +724,14 @@ public class GNodeImpl extends GArgumentableImpl implements GNode {
          case GraphPackage.GNODE__SIZE:
             setSize((GDimension) null);
             return;
+         case GraphPackage.GNODE__LAYOUT_OPTIONS:
+            getLayoutOptions().clear();
+            return;
          case GraphPackage.GNODE__EDGE_PLACEMENT:
             setEdgePlacement((GEdgePlacement) null);
             return;
          case GraphPackage.GNODE__LAYOUT:
             setLayout(LAYOUT_EDEFAULT);
-            return;
-         case GraphPackage.GNODE__LAYOUT_OPTIONS:
-            getLayoutOptions().clear();
             return;
       }
       super.eUnset(featureID);
@@ -760,12 +761,12 @@ public class GNodeImpl extends GArgumentableImpl implements GNode {
             return position != null;
          case GraphPackage.GNODE__SIZE:
             return size != null;
+         case GraphPackage.GNODE__LAYOUT_OPTIONS:
+            return layoutOptions != null && !layoutOptions.isEmpty();
          case GraphPackage.GNODE__EDGE_PLACEMENT:
             return edgePlacement != null;
          case GraphPackage.GNODE__LAYOUT:
             return LAYOUT_EDEFAULT == null ? layout != null : !LAYOUT_EDEFAULT.equals(layout);
-         case GraphPackage.GNODE__LAYOUT_OPTIONS:
-            return layoutOptions != null && !layoutOptions.isEmpty();
       }
       return super.eIsSet(featureID);
    }
@@ -787,6 +788,14 @@ public class GNodeImpl extends GArgumentableImpl implements GNode {
                return -1;
          }
       }
+      if (baseClass == GLayoutable.class) {
+         switch (derivedFeatureID) {
+            case GraphPackage.GNODE__LAYOUT_OPTIONS:
+               return GraphPackage.GLAYOUTABLE__LAYOUT_OPTIONS;
+            default:
+               return -1;
+         }
+      }
       if (baseClass == GEdgeLayoutable.class) {
          switch (derivedFeatureID) {
             case GraphPackage.GNODE__EDGE_PLACEMENT:
@@ -799,8 +808,6 @@ public class GNodeImpl extends GArgumentableImpl implements GNode {
          switch (derivedFeatureID) {
             case GraphPackage.GNODE__LAYOUT:
                return GraphPackage.GLAYOUTING__LAYOUT;
-            case GraphPackage.GNODE__LAYOUT_OPTIONS:
-               return GraphPackage.GLAYOUTING__LAYOUT_OPTIONS;
             default:
                return -1;
          }
@@ -825,6 +832,14 @@ public class GNodeImpl extends GArgumentableImpl implements GNode {
                return -1;
          }
       }
+      if (baseClass == GLayoutable.class) {
+         switch (baseFeatureID) {
+            case GraphPackage.GLAYOUTABLE__LAYOUT_OPTIONS:
+               return GraphPackage.GNODE__LAYOUT_OPTIONS;
+            default:
+               return -1;
+         }
+      }
       if (baseClass == GEdgeLayoutable.class) {
          switch (baseFeatureID) {
             case GraphPackage.GEDGE_LAYOUTABLE__EDGE_PLACEMENT:
@@ -837,8 +852,6 @@ public class GNodeImpl extends GArgumentableImpl implements GNode {
          switch (baseFeatureID) {
             case GraphPackage.GLAYOUTING__LAYOUT:
                return GraphPackage.GNODE__LAYOUT;
-            case GraphPackage.GLAYOUTING__LAYOUT_OPTIONS:
-               return GraphPackage.GNODE__LAYOUT_OPTIONS;
             default:
                return -1;
          }

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GPortImpl.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GPortImpl.java
@@ -23,18 +23,22 @@ import org.eclipse.emf.common.notify.NotificationChain;
 
 import org.eclipse.emf.common.util.EList;
 
+import org.eclipse.emf.common.util.EMap;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.InternalEObject;
 
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 
 import org.eclipse.emf.ecore.util.EDataTypeUniqueEList;
 import org.eclipse.emf.ecore.util.EObjectContainmentWithInverseEList;
+import org.eclipse.emf.ecore.util.EcoreEMap;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.util.InternalEList;
 
 import org.eclipse.glsp.graph.GBoundsAware;
 import org.eclipse.glsp.graph.GDimension;
+import org.eclipse.glsp.graph.GLayoutable;
 import org.eclipse.glsp.graph.GModelElement;
 import org.eclipse.glsp.graph.GPoint;
 import org.eclipse.glsp.graph.GPort;
@@ -56,6 +60,7 @@ import org.eclipse.glsp.graph.GraphPackage;
  *   <li>{@link org.eclipse.glsp.graph.impl.GPortImpl#getType <em>Type</em>}</li>
  *   <li>{@link org.eclipse.glsp.graph.impl.GPortImpl#getPosition <em>Position</em>}</li>
  *   <li>{@link org.eclipse.glsp.graph.impl.GPortImpl#getSize <em>Size</em>}</li>
+ *   <li>{@link org.eclipse.glsp.graph.impl.GPortImpl#getLayoutOptions <em>Layout Options</em>}</li>
  * </ul>
  *
  * @generated
@@ -160,6 +165,16 @@ public class GPortImpl extends GArgumentableImpl implements GPort {
     * @ordered
     */
    protected GDimension size;
+
+   /**
+    * The cached value of the '{@link #getLayoutOptions() <em>Layout Options</em>}' map.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @see #getLayoutOptions()
+    * @generated
+    * @ordered
+    */
+   protected EMap<String, Object> layoutOptions;
 
    /**
     * <!-- begin-user-doc -->
@@ -419,6 +434,20 @@ public class GPortImpl extends GArgumentableImpl implements GPort {
     * <!-- end-user-doc -->
     * @generated
     */
+   @Override
+   public EMap<String, Object> getLayoutOptions() {
+      if (layoutOptions == null) {
+         layoutOptions = new EcoreEMap<String, Object>(GraphPackage.Literals.STRING_TO_OBJECT_MAP_ENTRY,
+            StringToObjectMapEntryImpl.class, this, GraphPackage.GPORT__LAYOUT_OPTIONS);
+      }
+      return layoutOptions;
+   }
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
    @SuppressWarnings("unchecked")
    @Override
    public NotificationChain eInverseAdd(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
@@ -449,6 +478,8 @@ public class GPortImpl extends GArgumentableImpl implements GPort {
             return basicSetPosition(null, msgs);
          case GraphPackage.GPORT__SIZE:
             return basicSetSize(null, msgs);
+         case GraphPackage.GPORT__LAYOUT_OPTIONS:
+            return ((InternalEList<?>) getLayoutOptions()).basicRemove(otherEnd, msgs);
       }
       return super.eInverseRemove(otherEnd, featureID, msgs);
    }
@@ -492,6 +523,11 @@ public class GPortImpl extends GArgumentableImpl implements GPort {
             return getPosition();
          case GraphPackage.GPORT__SIZE:
             return getSize();
+         case GraphPackage.GPORT__LAYOUT_OPTIONS:
+            if (coreType)
+               return getLayoutOptions();
+            else
+               return getLayoutOptions().map();
       }
       return super.eGet(featureID, resolve, coreType);
    }
@@ -531,6 +567,9 @@ public class GPortImpl extends GArgumentableImpl implements GPort {
          case GraphPackage.GPORT__SIZE:
             setSize((GDimension) newValue);
             return;
+         case GraphPackage.GPORT__LAYOUT_OPTIONS:
+            ((EStructuralFeature.Setting) getLayoutOptions()).set(newValue);
+            return;
       }
       super.eSet(featureID, newValue);
    }
@@ -567,6 +606,9 @@ public class GPortImpl extends GArgumentableImpl implements GPort {
          case GraphPackage.GPORT__SIZE:
             setSize((GDimension) null);
             return;
+         case GraphPackage.GPORT__LAYOUT_OPTIONS:
+            getLayoutOptions().clear();
+            return;
       }
       super.eUnset(featureID);
    }
@@ -595,6 +637,8 @@ public class GPortImpl extends GArgumentableImpl implements GPort {
             return position != null;
          case GraphPackage.GPORT__SIZE:
             return size != null;
+         case GraphPackage.GPORT__LAYOUT_OPTIONS:
+            return layoutOptions != null && !layoutOptions.isEmpty();
       }
       return super.eIsSet(featureID);
    }
@@ -616,6 +660,14 @@ public class GPortImpl extends GArgumentableImpl implements GPort {
                return -1;
          }
       }
+      if (baseClass == GLayoutable.class) {
+         switch (derivedFeatureID) {
+            case GraphPackage.GPORT__LAYOUT_OPTIONS:
+               return GraphPackage.GLAYOUTABLE__LAYOUT_OPTIONS;
+            default:
+               return -1;
+         }
+      }
       return super.eBaseStructuralFeatureID(derivedFeatureID, baseClass);
    }
 
@@ -632,6 +684,14 @@ public class GPortImpl extends GArgumentableImpl implements GPort {
                return GraphPackage.GPORT__POSITION;
             case GraphPackage.GBOUNDS_AWARE__SIZE:
                return GraphPackage.GPORT__SIZE;
+            default:
+               return -1;
+         }
+      }
+      if (baseClass == GLayoutable.class) {
+         switch (baseFeatureID) {
+            case GraphPackage.GLAYOUTABLE__LAYOUT_OPTIONS:
+               return GraphPackage.GPORT__LAYOUT_OPTIONS;
             default:
                return -1;
          }

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GraphFactoryImpl.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GraphFactoryImpl.java
@@ -112,6 +112,8 @@ public class GraphFactoryImpl extends EFactoryImpl implements GraphFactory {
             return createGShapePreRenderedElement();
          case GraphPackage.STRING_TO_OBJECT_MAP_ENTRY:
             return (EObject) createStringToObjectMapEntry();
+         case GraphPackage.GLAYOUTABLE:
+            return createGLayoutable();
          default:
             throw new IllegalArgumentException("The class '" + eClass.getName() + "' is not a valid classifier");
       }
@@ -357,13 +359,24 @@ public class GraphFactoryImpl extends EFactoryImpl implements GraphFactory {
    }
 
    /**
-   	 * <!-- begin-user-doc -->
+    * <!-- begin-user-doc -->
     * <!-- end-user-doc -->
-   	 * @generated
-   	 */
+    * @generated
+    */
    public Map.Entry<String, Object> createStringToObjectMapEntry() {
       StringToObjectMapEntryImpl stringToObjectMapEntry = new StringToObjectMapEntryImpl();
       return stringToObjectMapEntry;
+   }
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   @Override
+   public GLayoutable createGLayoutable() {
+      GLayoutableImpl gLayoutable = new GLayoutableImpl();
+      return gLayoutable;
    }
 
    /**

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GraphPackageImpl.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GraphPackageImpl.java
@@ -41,6 +41,7 @@ import org.eclipse.glsp.graph.GHtmlRoot;
 import org.eclipse.glsp.graph.GIssue;
 import org.eclipse.glsp.graph.GIssueMarker;
 import org.eclipse.glsp.graph.GLabel;
+import org.eclipse.glsp.graph.GLayoutable;
 import org.eclipse.glsp.graph.GLayouting;
 import org.eclipse.glsp.graph.GModelElement;
 import org.eclipse.glsp.graph.GModelRoot;
@@ -230,11 +231,18 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
    private EClass gShapePreRenderedElementEClass = null;
 
    /**
-   	 * <!-- begin-user-doc -->
+    * <!-- begin-user-doc -->
     * <!-- end-user-doc -->
-   	 * @generated
-   	 */
+    * @generated
+    */
    private EClass stringToObjectMapEntryEClass = null;
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   private EClass gLayoutableEClass = null;
 
    /**
     * <!-- begin-user-doc -->
@@ -388,14 +396,6 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
     */
    @Override
    public EClass getGGraph() { return gGraphEClass; }
-
-   /**
-    * <!-- begin-user-doc -->
-    * <!-- end-user-doc -->
-    * @generated
-    */
-   @Override
-   public EReference getGGraph_LayoutOptions() { return (EReference) gGraphEClass.getEStructuralFeatures().get(0); }
 
    /**
     * <!-- begin-user-doc -->
@@ -715,16 +715,6 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
     * @generated
     */
    @Override
-   public EReference getGLayouting_LayoutOptions() {
-      return (EReference) gLayoutingEClass.getEStructuralFeatures().get(1);
-   }
-
-   /**
-    * <!-- begin-user-doc -->
-    * <!-- end-user-doc -->
-    * @generated
-    */
-   @Override
    public EClass getGBounds() { return gBoundsEClass; }
 
    /**
@@ -860,10 +850,10 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
    public EClass getGShapePreRenderedElement() { return gShapePreRenderedElementEClass; }
 
    /**
-   	 * <!-- begin-user-doc -->
+    * <!-- begin-user-doc -->
     * <!-- end-user-doc -->
-   	 * @generated
-   	 */
+    * @generated
+    */
    @Override
    public EClass getStringToObjectMapEntry() { return stringToObjectMapEntryEClass; }
 
@@ -885,6 +875,24 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
    @Override
    public EAttribute getStringToObjectMapEntry_Value() {
       return (EAttribute) stringToObjectMapEntryEClass.getEStructuralFeatures().get(1);
+   }
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   @Override
+   public EClass getGLayoutable() { return gLayoutableEClass; }
+
+   /**
+    * <!-- begin-user-doc -->
+   	 * <!-- end-user-doc -->
+    * @generated
+    */
+   @Override
+   public EReference getGLayoutable_LayoutOptions() {
+      return (EReference) gLayoutableEClass.getEStructuralFeatures().get(0);
    }
 
    /**
@@ -934,7 +942,6 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
       gShapeElementEClass = createEClass(GSHAPE_ELEMENT);
 
       gGraphEClass = createEClass(GGRAPH);
-      createEReference(gGraphEClass, GGRAPH__LAYOUT_OPTIONS);
 
       gModelRootEClass = createEClass(GMODEL_ROOT);
       createEReference(gModelRootEClass, GMODEL_ROOT__CANVAS_BOUNDS);
@@ -986,7 +993,6 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
 
       gLayoutingEClass = createEClass(GLAYOUTING);
       createEAttribute(gLayoutingEClass, GLAYOUTING__LAYOUT);
-      createEReference(gLayoutingEClass, GLAYOUTING__LAYOUT_OPTIONS);
 
       gBoundsEClass = createEClass(GBOUNDS);
       createEAttribute(gBoundsEClass, GBOUNDS__X);
@@ -1015,6 +1021,9 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
       stringToObjectMapEntryEClass = createEClass(STRING_TO_OBJECT_MAP_ENTRY);
       createEAttribute(stringToObjectMapEntryEClass, STRING_TO_OBJECT_MAP_ENTRY__KEY);
       createEAttribute(stringToObjectMapEntryEClass, STRING_TO_OBJECT_MAP_ENTRY__VALUE);
+
+      gLayoutableEClass = createEClass(GLAYOUTABLE);
+      createEReference(gLayoutableEClass, GLAYOUTABLE__LAYOUT_OPTIONS);
 
       // Create enums
       gSeverityEEnum = createEEnum(GSEVERITY);
@@ -1052,8 +1061,10 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
       gModelElementEClass.getESuperTypes().add(this.getGArgumentable());
       gShapeElementEClass.getESuperTypes().add(this.getGModelElement());
       gShapeElementEClass.getESuperTypes().add(this.getGBoundsAware());
+      gShapeElementEClass.getESuperTypes().add(this.getGLayoutable());
       gGraphEClass.getESuperTypes().add(this.getGModelRoot());
       gGraphEClass.getESuperTypes().add(this.getGBoundsAware());
+      gGraphEClass.getESuperTypes().add(this.getGLayoutable());
       gModelRootEClass.getESuperTypes().add(this.getGModelElement());
       gNodeEClass.getESuperTypes().add(this.getGShapeElement());
       gNodeEClass.getESuperTypes().add(this.getGEdgeLayoutable());
@@ -1067,6 +1078,7 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
       gIssueMarkerEClass.getESuperTypes().add(this.getGShapeElement());
       gPortEClass.getESuperTypes().add(this.getGShapeElement());
       gButtonEClass.getESuperTypes().add(this.getGShapeElement());
+      gLayoutingEClass.getESuperTypes().add(this.getGLayoutable());
       gHtmlRootEClass.getESuperTypes().add(this.getGModelRoot());
       gPreRenderedElementEClass.getESuperTypes().add(this.getGModelElement());
       gShapePreRenderedElementEClass.getESuperTypes().add(this.getGPreRenderedElement());
@@ -1095,9 +1107,6 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
          IS_GENERATED_INSTANCE_CLASS);
 
       initEClass(gGraphEClass, GGraph.class, "GGraph", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-      initEReference(getGGraph_LayoutOptions(), this.getStringToObjectMapEntry(), null, "layoutOptions", null, 0, -1,
-         GGraph.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE,
-         IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
       initEClass(gModelRootEClass, GModelRoot.class, "GModelRoot", !IS_ABSTRACT, !IS_INTERFACE,
          IS_GENERATED_INSTANCE_CLASS);
@@ -1190,9 +1199,6 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
          IS_GENERATED_INSTANCE_CLASS);
       initEAttribute(getGLayouting_Layout(), ecorePackage.getEString(), "layout", null, 0, 1, GLayouting.class,
          !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-      initEReference(getGLayouting_LayoutOptions(), this.getStringToObjectMapEntry(), null, "layoutOptions", null, 0,
-         -1, GLayouting.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES,
-         !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
       initEClass(gBoundsEClass, GBounds.class, "GBounds", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
       initEAttribute(getGBounds_X(), ecorePackage.getEDouble(), "x", "0", 1, 1, GBounds.class, !IS_TRANSIENT,
@@ -1243,6 +1249,12 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
       initEAttribute(getStringToObjectMapEntry_Value(), ecorePackage.getEJavaObject(), "value", null, 0, 1,
          Map.Entry.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED,
          IS_ORDERED);
+
+      initEClass(gLayoutableEClass, GLayoutable.class, "GLayoutable", !IS_ABSTRACT, !IS_INTERFACE,
+         IS_GENERATED_INSTANCE_CLASS);
+      initEReference(getGLayoutable_LayoutOptions(), this.getStringToObjectMapEntry(), null, "layoutOptions", null, 0,
+         -1, GLayoutable.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES,
+         !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
       // Initialize enums and add enum literals
       initEEnum(gSeverityEEnum, GSeverity.class, "GSeverity");

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/util/GraphAdapterFactory.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/util/GraphAdapterFactory.java
@@ -208,6 +208,11 @@ public class GraphAdapterFactory extends AdapterFactoryImpl {
       }
 
       @Override
+      public Adapter caseGLayoutable(GLayoutable object) {
+         return createGLayoutableAdapter();
+      }
+
+      @Override
       public Adapter defaultCase(EObject object) {
          return createEObjectAdapter();
       }
@@ -563,16 +568,30 @@ public class GraphAdapterFactory extends AdapterFactoryImpl {
    }
 
    /**
-   	 * Creates a new adapter for an object of class '{@link java.util.Map.Entry <em>String To Object Map Entry</em>}'.
-   	 * <!-- begin-user-doc -->
+    * Creates a new adapter for an object of class '{@link java.util.Map.Entry <em>String To Object Map Entry</em>}'.
+    * <!-- begin-user-doc -->
     * This default implementation returns null so that we can easily ignore cases;
     * it's useful to ignore a case when inheritance will catch all the cases anyway.
     * <!-- end-user-doc -->
-   	 * @return the new adapter.
-   	 * @see java.util.Map.Entry
-   	 * @generated
-   	 */
+    * @return the new adapter.
+    * @see java.util.Map.Entry
+    * @generated
+    */
    public Adapter createStringToObjectMapEntryAdapter() {
+      return null;
+   }
+
+   /**
+    * Creates a new adapter for an object of class '{@link org.eclipse.glsp.graph.GLayoutable <em>GLayoutable</em>}'.
+    * <!-- begin-user-doc -->
+    * This default implementation returns null so that we can easily ignore cases;
+    * it's useful to ignore a case when inheritance will catch all the cases anyway.
+    * <!-- end-user-doc -->
+    * @return the new adapter.
+    * @see org.eclipse.glsp.graph.GLayoutable
+    * @generated
+    */
+   public Adapter createGLayoutableAdapter() {
       return null;
    }
 

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/util/GraphSwitch.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/util/GraphSwitch.java
@@ -99,6 +99,8 @@ public class GraphSwitch<T> extends Switch<T> {
             if (result == null)
                result = caseGBoundsAware(gShapeElement);
             if (result == null)
+               result = caseGLayoutable(gShapeElement);
+            if (result == null)
                result = caseGArgumentable(gShapeElement);
             if (result == null)
                result = defaultCase(theEObject);
@@ -111,6 +113,8 @@ public class GraphSwitch<T> extends Switch<T> {
                result = caseGModelRoot(gGraph);
             if (result == null)
                result = caseGBoundsAware(gGraph);
+            if (result == null)
+               result = caseGLayoutable(gGraph);
             if (result == null)
                result = caseGModelElement(gGraph);
             if (result == null)
@@ -144,6 +148,8 @@ public class GraphSwitch<T> extends Switch<T> {
             if (result == null)
                result = caseGBoundsAware(gNode);
             if (result == null)
+               result = caseGLayoutable(gNode);
+            if (result == null)
                result = caseGArgumentable(gNode);
             if (result == null)
                result = defaultCase(theEObject);
@@ -172,6 +178,8 @@ public class GraphSwitch<T> extends Switch<T> {
             if (result == null)
                result = caseGBoundsAware(gCompartment);
             if (result == null)
+               result = caseGLayoutable(gCompartment);
+            if (result == null)
                result = caseGArgumentable(gCompartment);
             if (result == null)
                result = defaultCase(theEObject);
@@ -191,6 +199,8 @@ public class GraphSwitch<T> extends Switch<T> {
             if (result == null)
                result = caseGBoundsAware(gLabel);
             if (result == null)
+               result = caseGLayoutable(gLabel);
+            if (result == null)
                result = caseGArgumentable(gLabel);
             if (result == null)
                result = defaultCase(theEObject);
@@ -205,6 +215,8 @@ public class GraphSwitch<T> extends Switch<T> {
                result = caseGModelElement(gIssueMarker);
             if (result == null)
                result = caseGBoundsAware(gIssueMarker);
+            if (result == null)
+               result = caseGLayoutable(gIssueMarker);
             if (result == null)
                result = caseGArgumentable(gIssueMarker);
             if (result == null)
@@ -221,6 +233,8 @@ public class GraphSwitch<T> extends Switch<T> {
             if (result == null)
                result = caseGBoundsAware(gPort);
             if (result == null)
+               result = caseGLayoutable(gPort);
+            if (result == null)
                result = caseGArgumentable(gPort);
             if (result == null)
                result = defaultCase(theEObject);
@@ -235,6 +249,8 @@ public class GraphSwitch<T> extends Switch<T> {
                result = caseGModelElement(gButton);
             if (result == null)
                result = caseGBoundsAware(gButton);
+            if (result == null)
+               result = caseGLayoutable(gButton);
             if (result == null)
                result = caseGArgumentable(gButton);
             if (result == null)
@@ -279,6 +295,8 @@ public class GraphSwitch<T> extends Switch<T> {
          case GraphPackage.GLAYOUTING: {
             GLayouting gLayouting = (GLayouting) theEObject;
             T result = caseGLayouting(gLayouting);
+            if (result == null)
+               result = caseGLayoutable(gLayouting);
             if (result == null)
                result = defaultCase(theEObject);
             return result;
@@ -354,6 +372,13 @@ public class GraphSwitch<T> extends Switch<T> {
             @SuppressWarnings("unchecked")
             Map.Entry<String, Object> stringToObjectMapEntry = (Map.Entry<String, Object>) theEObject;
             T result = caseStringToObjectMapEntry(stringToObjectMapEntry);
+            if (result == null)
+               result = defaultCase(theEObject);
+            return result;
+         }
+         case GraphPackage.GLAYOUTABLE: {
+            GLayoutable gLayoutable = (GLayoutable) theEObject;
+            T result = caseGLayoutable(gLayoutable);
             if (result == null)
                result = defaultCase(theEObject);
             return result;
@@ -724,17 +749,32 @@ public class GraphSwitch<T> extends Switch<T> {
    }
 
    /**
-   	 * Returns the result of interpreting the object as an instance of '<em>String To Object Map Entry</em>'.
-   	 * <!-- begin-user-doc -->
+    * Returns the result of interpreting the object as an instance of '<em>String To Object Map Entry</em>'.
+    * <!-- begin-user-doc -->
     * This implementation returns null;
     * returning a non-null result will terminate the switch.
     * <!-- end-user-doc -->
-   	 * @param object the target of the switch.
-   	 * @return the result of interpreting the object as an instance of '<em>String To Object Map Entry</em>'.
-   	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
-   	 * @generated
-   	 */
+    * @param object the target of the switch.
+    * @return the result of interpreting the object as an instance of '<em>String To Object Map Entry</em>'.
+    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+    * @generated
+    */
    public T caseStringToObjectMapEntry(Map.Entry<String, Object> object) {
+      return null;
+   }
+
+   /**
+    * Returns the result of interpreting the object as an instance of '<em>GLayoutable</em>'.
+    * <!-- begin-user-doc -->
+    * This implementation returns null;
+    * returning a non-null result will terminate the switch.
+    * <!-- end-user-doc -->
+    * @param object the target of the switch.
+    * @return the result of interpreting the object as an instance of '<em>GLayoutable</em>'.
+    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+    * @generated
+    */
+   public T caseGLayoutable(GLayoutable object) {
       return null;
    }
 


### PR DESCRIPTION
- Update the Graph model for consistency with the Sprotty API
- GShapeElement is a GLayoutable and can have layoutOptions

refs https://github.com/eclipse-glsp/glsp/issues/694

Contributed on behalf of STMicroelectronics.