### PR TITLE
#622 Add glsp.server.emf source to p2 plugin

### DIFF
--- a/releng/org.eclipse.glsp.repository/category.xml
+++ b/releng/org.eclipse.glsp.repository/category.xml
@@ -27,6 +27,9 @@
    <bundle id="org.eclipse.glsp.server.emf">
       <category name="org.eclipse.glsp"/>
    </bundle>
+   <bundle id="org.eclipse.glsp.server.emf.source">
+      <category name="org.eclipse.glsp"/>
+   </bundle>
    <category-def name="org.eclipse.glsp" label="Eclipse GLSP"/>
    <category-def name="org.eclipse.glsp.examples" label="GLSP Examples"/>
 </site>


### PR DESCRIPTION
Follow-up of https://github.com/eclipse-glsp/glsp/issues/622
- Add `glsp.server.emf.source` to p2 plugin to improve development experience