### PR TITLE
Update tycho maven version: 2.3.0 => 2.7.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
 			</activation>
 
 			<properties>
-				<tycho-version>2.3.0</tycho-version>
+				<tycho-version>2.7.5</tycho-version>
 				<maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
 			</properties>
 
@@ -180,7 +180,7 @@
 						<groupId>org.eclipse.tycho</groupId>
 						<artifactId>target-platform-configuration</artifactId>
 						<configuration>
-							<includePackedArtifacts>true</includePackedArtifacts>
+							<includePackedArtifacts>false</includePackedArtifacts>
 							<targetDefinitionIncludeSource>honor</targetDefinitionIncludeSource>
 							<environments>
 								<environment>

--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,6 @@
 						<groupId>org.eclipse.tycho</groupId>
 						<artifactId>target-platform-configuration</artifactId>
 						<configuration>
-							<includePackedArtifacts>false</includePackedArtifacts>
 							<targetDefinitionIncludeSource>honor</targetDefinitionIncludeSource>
 							<environments>
 								<environment>

--- a/targetplatforms/pom.xml
+++ b/targetplatforms/pom.xml
@@ -14,8 +14,8 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho-version>2.1.0</tycho-version>
-		<tycho-extras-version>2.1.0</tycho-extras-version>
+		<tycho-version>2.7.5</tycho-version>
+		<tycho-extras-version>2.7.5</tycho-extras-version>
 		<targetPlatform.application.name>org.eclipse.cbi.targetplatform.tpd.converter</targetPlatform.application.name>
 		<targetPlatform.application.args>r2020-06.tpd</targetPlatform.application.args>
 	</properties>


### PR DESCRIPTION
This is needed to build with maven and Java 17.
Related to this, includePackedArtifacts had to be disabled as it seems to cause issues with Java 14 and higher.

Closes https://github.com/eclipse-glsp/glsp/issues/750

Signed-off-by: Olaf Lessenich <olessenich@eclipsesource.com>