### PR TITLE
don't wait on stdin in websocket server

### DIFF
--- a/plugins/org.eclipse.glsp.server.websocket/src/org/eclipse/glsp/server/websocket/WebsocketServerLauncher.java
+++ b/plugins/org.eclipse.glsp.server.websocket/src/org/eclipse/glsp/server/websocket/WebsocketServerLauncher.java
@@ -79,20 +79,6 @@ public class WebsocketServerLauncher extends GLSPServerLauncher {
          try {
             server.start();
             LOGGER.info("GLSP server is running and listening on Endpoint : " + server.getURI() + endpointPath);
-            LOGGER.info("Press enter to stop the server...");
-            new Thread(() -> {
-               try {
-                  int key = System.in.read();
-                  this.shutdown();
-                  if (key == -1) {
-                     LOGGER.warn("The standard input stream is empty");
-                  }
-               } catch (IOException e) {
-                  LOGGER.warn(e);
-               }
-
-            }).start();
-
             server.join();
          } catch (Exception exception) {
             LOGGER.warn("Shutting down due to exception", exception);

--- a/plugins/org.eclipse.glsp.server.websocket/src/org/eclipse/glsp/server/websocket/WebsocketServerLauncher.java
+++ b/plugins/org.eclipse.glsp.server.websocket/src/org/eclipse/glsp/server/websocket/WebsocketServerLauncher.java
@@ -15,7 +15,6 @@
  ******************************************************************************/
 package org.eclipse.glsp.server.websocket;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 
 import javax.websocket.server.ServerEndpointConfig;


### PR DESCRIPTION
closes https://github.com/eclipse-glsp/glsp/issues/883

remove listening on stdin, so that the server can be started without access to stdin and rely on process control to stop