### PR TITLE
Ensure existing IdKeeperAdapters are found

### DIFF
--- a/plugins/org.eclipse.glsp.graph/src/org/eclipse/glsp/graph/util/IdKeeperAdapter.java
+++ b/plugins/org.eclipse.glsp.graph/src/org/eclipse/glsp/graph/util/IdKeeperAdapter.java
@@ -19,7 +19,6 @@ import java.util.UUID;
 
 import org.eclipse.emf.common.notify.Notifier;
 import org.eclipse.emf.common.notify.impl.AdapterImpl;
-import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 
 public class IdKeeperAdapter extends AdapterImpl {
@@ -39,7 +38,7 @@ public class IdKeeperAdapter extends AdapterImpl {
 
    @Override
    public boolean isAdapterForType(final Object type) {
-      return type instanceof EObject;
+      return type == IdKeeperAdapter.class;
    }
 
    public static IdKeeperAdapter getOrCreate(final Notifier notifier) {


### PR DESCRIPTION
This is crucial to make sure that IDs are stable with UUIDIdGenerator within one session.

Fixes https://github.com/eclipse-glsp/glsp/issues/897
Contributed on behalf of STMicroelectronics.