### PR TITLE
chore: align startup message to include port number

### DIFF
--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/launch/SocketGLSPServerLauncher.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/launch/SocketGLSPServerLauncher.java
@@ -45,7 +45,7 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 
 public class SocketGLSPServerLauncher extends GLSPServerLauncher {
-   public static final String START_UP_COMPLETE_MSG = "[GLSP-Server]:Startup completed";
+   public static final String START_UP_COMPLETE_MSG = "[GLSP-Server]:Startup completed. Accepting requests on port:";
    private static Logger LOGGER = LogManager.getLogger(SocketGLSPServerLauncher.class);
 
    private ExecutorService threadPool;
@@ -96,7 +96,7 @@ public class SocketGLSPServerLauncher extends GLSPServerLauncher {
       LOGGER.info("The GLSP server is ready to accept new client requests on port: " + port);
       // Print a message to the output stream that indicates that the start is completed.
       // This indicates to the client that the sever process is ready (in an embedded scenario).
-      System.out.println(getStartupCompleteMessage());
+      System.out.println(getStartupCompleteMessage() + port);
 
       return onShutdown;
    }


### PR DESCRIPTION
To be compliant with the behavior of glsp-server-node, the startup message has to include the port of the socket.

Fixes https://github.com/eclipse-glsp/glsp/issues/825