### PR TITLE
feat: adjust server startup to use autoassigned ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   - EMFModelStateImpl and EMFNotationModelStateImpl classes have been added
   - Related Modules have been updated to inject these GModelState sub-types as a Singleton
 - [validation] Add explicit support and API for live and batch validation [#200](https://github.com/eclipse-glsp/glsp-server/pull/200)
+- [server] Default ports have changed from 5007 (and 8081 for websockets) to 0, which implies autoassignment by the OS [#198](https://github.com/eclipse-glsp/glsp-server/pull/198)
 
 ## [v1.0.0 - 30/06/2022](https://github.com/eclipse-glsp/glsp-server/releases/tag/v1.0.0)
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To run the Workflow Diagram example server standalone JAR, run this command in y
     -j,--jettyLogLevel <arg>   Set the log level for the Jetty websocket server.
                                 [default='INFO']
     -l,--logLevel <arg>        Set the log level. [default='INFO']
-    -p,--port <arg>            Set server port. [default='5007']
+    -p,--port <arg>            Set server port. [default='0']
     -w,--websocket             Use websocket launcher instead of default launcher.
 ```
 

--- a/examples/org.eclipse.glsp.example.workflow/Start_Workflow_Example_Server.launch
+++ b/examples/org.eclipse.glsp.example.workflow/Start_Workflow_Example_Server.launch
@@ -11,7 +11,7 @@
     <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.glsp.example.workflow.launch.WorkflowServerLauncher"/>
     <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="org.eclipse.glsp.example.workflow"/>
-    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="--logLevel=debug"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="--logLevel=debug&#10;--port=5007"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.glsp.example.workflow"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
 </launchConfiguration>

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/utils/LaunchUtil.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/utils/LaunchUtil.java
@@ -48,7 +48,7 @@ public final class LaunchUtil {
    private LaunchUtil() {}
 
    public static final class DefaultOptions {
-      public static final int SERVER_PORT = 5007;
+      public static final int SERVER_PORT = 0;
       public static final Level LOG_LEVEL = Level.INFO;
       public static final String LOG_DIR = new File("./logs/").getAbsolutePath();
       public static final boolean CONSOLE_LOG_ENABLED = true;


### PR DESCRIPTION
This sets the default port to 0, which will cause the server to automatically assign a port. The port is then printed to the console in the startup message and can be parsed by clients.

Part of eclipse-glsp/glsp#965