### PR TITLE
GLSP-974: Use interface-injection for all subclasses of ModelState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 - [operation] Rework `OperationHandler` to provide an optional command instead of direct execution to allow more execution control [#187](https://github.com/eclipse-glsp/glsp-server/pull/187)
   - `Abstract<XYZ>` base implementations were deprecated in favor of `GModelOperationHandler` and `EMFOperationHandler` base classes
   - Long-term deprecated and unused `Basic<XYZ>` base classes were removed
+- [modelstate] Use interface-injection for all subclasses of GModelState (EMFModelState, EMFNotationModelState)
+  - EMFModelState and EMFNotationModelState are now interfaces instead of classes
+  - EMFModelStateImpl and EMFNotationModelStateImpl classes have been added
+  - Related Modules have been updated to inject these GModelState sub-types as a Singleton
 
 ## [v1.0.0 - 30/06/2022](https://github.com/eclipse-glsp/glsp-server/releases/tag/v1.0.0)
 

--- a/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/EMFDiagramModule.java
+++ b/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/EMFDiagramModule.java
@@ -16,7 +16,6 @@
 package org.eclipse.glsp.server.emf;
 
 import org.eclipse.glsp.server.di.DiagramModule;
-import org.eclipse.glsp.server.model.GModelState;
 
 import com.google.inject.Singleton;
 
@@ -51,7 +50,7 @@ public abstract class EMFDiagramModule extends DiagramModule {
 
    @Override
    protected Class<? extends EMFModelState> bindGModelState() {
-      return EMFModelState.class;
+      return EMFModelStateImpl.class;
    }
 
    @Override
@@ -60,10 +59,13 @@ public abstract class EMFDiagramModule extends DiagramModule {
    }
 
    @Override
-   @SuppressWarnings("unchecked")
-   protected void configureGModelState(final Class<? extends GModelState> gmodelStateClass) {
-      super.configureGModelState(gmodelStateClass);
-      bind(EMFModelState.class).to((Class<? extends EMFModelState>) gmodelStateClass);
+   protected void configure() {
+      super.configure();
+      configureEMFModelState(bindGModelState());
+   }
+
+   protected void configureEMFModelState(final Class<? extends EMFModelState> emfStateClass) {
+      bind(EMFModelState.class).to(emfStateClass).in(Singleton.class);
    }
 
 }

--- a/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/EMFModelState.java
+++ b/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/EMFModelState.java
@@ -3,11 +3,16 @@
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
- * available at https://opensource.org/licenses/MIT.
+ * https://www.eclipse.org/legal/epl-2.0.
  *
- * SPDX-License-Identifier: EPL-2.0 OR MIT
- ********************************************************************************/
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ******************************************************************************/
 package org.eclipse.glsp.server.emf;
 
 import org.eclipse.emf.ecore.resource.ResourceSet;

--- a/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/EMFModelState.java
+++ b/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/EMFModelState.java
@@ -15,7 +15,7 @@ import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.glsp.server.model.GModelState;
 
 public interface EMFModelState extends GModelState {
-   void setEditingDomain(final EditingDomain editingDomain);
+   void setEditingDomain(EditingDomain editingDomain);
 
    EditingDomain getEditingDomain();
 

--- a/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/EMFModelState.java
+++ b/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/EMFModelState.java
@@ -1,110 +1,26 @@
 /********************************************************************************
- * Copyright (c) 2022 EclipseSource and others.
+ * Copyright (c) 2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
  *
- * This Source Code may also be made available under the following Secondary
- * Licenses when the conditions for such availability set forth in the Eclipse
- * Public License v. 2.0 are satisfied: GNU General Public License, version 2
- * with the GNU Classpath Exception which is available at
- * https://www.gnu.org/software/classpath/license.html.
- *
- * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
  ********************************************************************************/
 package org.eclipse.glsp.server.emf;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.eclipse.emf.common.command.CommandStack;
-import org.eclipse.emf.common.util.EList;
-import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.edit.domain.EditingDomain;
-import org.eclipse.glsp.graph.GModelIndex;
-import org.eclipse.glsp.graph.GModelRoot;
-import org.eclipse.glsp.server.model.DefaultGModelState;
-import org.eclipse.glsp.server.session.ClientSession;
-import org.eclipse.glsp.server.session.ClientSessionListener;
-import org.eclipse.glsp.server.session.ClientSessionManager;
+import org.eclipse.glsp.server.model.GModelState;
 
-import com.google.inject.Inject;
+public interface EMFModelState extends GModelState {
+   void setEditingDomain(final EditingDomain editingDomain);
 
-/**
- * Model state that holds the status of an arbitrary EMF model in an EMF {@link ResourceSet}.
- *
- * This model state is intended to be used if your source model is an EMF model.
- * Therefore, this model state includes an {@link EMFModelIndex}, is able to execute commands via
- * its {@link CommandStack} using and {@link EditingDomain} and is registered as {@link ClientSessionListener} to be
- * able to reset the EMF resources on diagram close.
- *
- * @see EMFDiagramModule
- */
-public class EMFModelState extends DefaultGModelState implements ClientSessionListener {
+   EditingDomain getEditingDomain();
 
-   private static Logger LOGGER = LogManager.getLogger(EMFModelState.class.getSimpleName());
-
-   @Inject
-   protected ClientSessionManager clientSessionManager;
-
-   @Inject
-   protected EMFIdGenerator idGenerator;
-
-   protected EditingDomain editingDomain;
+   ResourceSet getResourceSet();
 
    @Override
-   @Inject
-   public void init() {
-      this.clientSessionManager.addListener(this, this.clientId);
-   }
-
-   public void setEditingDomain(final EditingDomain editingDomain) {
-      this.editingDomain = editingDomain;
-      setCommandStack(this.editingDomain.getCommandStack());
-   }
-
-   public EditingDomain getEditingDomain() { return editingDomain; }
-
-   public ResourceSet getResourceSet() { return editingDomain == null ? null : editingDomain.getResourceSet(); }
-
-   @Override
-   protected GModelIndex getOrUpdateIndex(final GModelRoot newRoot) {
-      return EMFModelIndex.getOrCreate(getRoot(), idGenerator);
-   }
-
-   @Override
-   public EMFModelIndex getIndex() { return (EMFModelIndex) super.getIndex(); }
-
-   @Override
-   public void sessionDisposed(final ClientSession clientSession) {
-      this.index.clear();
-      closeResourceSet();
-   }
-
-   @SuppressWarnings("checkstyle:IllegalCatch")
-   protected void closeResourceSet() {
-      if (getResourceSet() == null) {
-         return;
-      }
-      boolean result = false;
-      EList<Resource> resourceList = getResourceSet().getResources();
-      for (Resource resource : resourceList) {
-         if (resource.getURI() != null) {
-            try {
-               resource.unload();
-               result = true;
-            } catch (RuntimeException e) {
-               result = false;
-               LOGGER.error("Could not unload resource: " + resource.getURI(), e);
-               break;
-            }
-         }
-      }
-      if (result) {
-         commandStack.flush();
-         saveIsDone();
-      }
-   }
-
+   EMFModelIndex getIndex();
 }

--- a/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/EMFModelStateImpl.java
+++ b/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/EMFModelStateImpl.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022 EclipseSource and others.
+ * Copyright (c) 2022-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/EMFModelStateImpl.java
+++ b/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/EMFModelStateImpl.java
@@ -1,0 +1,113 @@
+/********************************************************************************
+ * Copyright (c) 2022 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.server.emf;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.eclipse.emf.common.command.CommandStack;
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.glsp.graph.GModelIndex;
+import org.eclipse.glsp.graph.GModelRoot;
+import org.eclipse.glsp.server.model.DefaultGModelState;
+import org.eclipse.glsp.server.session.ClientSession;
+import org.eclipse.glsp.server.session.ClientSessionListener;
+import org.eclipse.glsp.server.session.ClientSessionManager;
+
+import com.google.inject.Inject;
+
+/**
+ * Model state that holds the status of an arbitrary EMF model in an EMF {@link ResourceSet}.
+ *
+ * This model state is intended to be used if your source model is an EMF model.
+ * Therefore, this model state includes an {@link EMFModelIndex}, is able to execute commands via
+ * its {@link CommandStack} using and {@link EditingDomain} and is registered as {@link ClientSessionListener} to be
+ * able to reset the EMF resources on diagram close.
+ *
+ * @see EMFDiagramModule
+ */
+public class EMFModelStateImpl extends DefaultGModelState implements EMFModelState, ClientSessionListener {
+
+   private static Logger LOGGER = LogManager.getLogger(EMFModelStateImpl.class.getSimpleName());
+
+   @Inject
+   protected ClientSessionManager clientSessionManager;
+
+   @Inject
+   protected EMFIdGenerator idGenerator;
+
+   protected EditingDomain editingDomain;
+
+   @Override
+   @Inject
+   public void init() {
+      this.clientSessionManager.addListener(this, this.clientId);
+   }
+
+   @Override
+   public void setEditingDomain(final EditingDomain editingDomain) {
+      this.editingDomain = editingDomain;
+      setCommandStack(this.editingDomain.getCommandStack());
+   }
+
+   @Override
+   public EditingDomain getEditingDomain() { return editingDomain; }
+
+   @Override
+   public ResourceSet getResourceSet() { return editingDomain == null ? null : editingDomain.getResourceSet(); }
+
+   @Override
+   protected GModelIndex getOrUpdateIndex(final GModelRoot newRoot) {
+      return EMFModelIndex.getOrCreate(getRoot(), idGenerator);
+   }
+
+   @Override
+   public EMFModelIndex getIndex() { return (EMFModelIndex) super.getIndex(); }
+
+   @Override
+   public void sessionDisposed(final ClientSession clientSession) {
+      this.index.clear();
+      closeResourceSet();
+   }
+
+   @SuppressWarnings("checkstyle:IllegalCatch")
+   protected void closeResourceSet() {
+      if (getResourceSet() == null) {
+         return;
+      }
+      boolean result = false;
+      EList<Resource> resourceList = getResourceSet().getResources();
+      for (Resource resource : resourceList) {
+         if (resource.getURI() != null) {
+            try {
+               resource.unload();
+               result = true;
+            } catch (RuntimeException e) {
+               result = false;
+               LOGGER.error("Could not unload resource: " + resource.getURI(), e);
+               break;
+            }
+         }
+      }
+      if (result) {
+         commandStack.flush();
+         saveIsDone();
+      }
+   }
+
+}

--- a/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/EMFModelStateImpl.java
+++ b/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/EMFModelStateImpl.java
@@ -30,6 +30,7 @@ import org.eclipse.glsp.server.session.ClientSessionListener;
 import org.eclipse.glsp.server.session.ClientSessionManager;
 
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 
 /**
  * Model state that holds the status of an arbitrary EMF model in an EMF {@link ResourceSet}.
@@ -41,6 +42,7 @@ import com.google.inject.Inject;
  *
  * @see EMFDiagramModule
  */
+@Singleton
 public class EMFModelStateImpl extends DefaultGModelState implements EMFModelState, ClientSessionListener {
 
    private static Logger LOGGER = LogManager.getLogger(EMFModelStateImpl.class.getSimpleName());

--- a/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/notation/EMFNotationDiagramModule.java
+++ b/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/notation/EMFNotationDiagramModule.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022 EclipseSource and others.
+ * Copyright (c) 2022-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/notation/EMFNotationDiagramModule.java
+++ b/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/notation/EMFNotationDiagramModule.java
@@ -45,7 +45,7 @@ public abstract class EMFNotationDiagramModule extends EMFDiagramModule {
 
    @Override
    protected Class<? extends EMFNotationModelState> bindGModelState() {
-      return EMFNotationModelState.class;
+      return EMFNotationModelStateImpl.class;
    }
 
    @Override
@@ -57,6 +57,16 @@ public abstract class EMFNotationDiagramModule extends EMFDiagramModule {
    protected void configureOperationHandlers(final MultiBinding<OperationHandler<?>> binding) {
       super.configureOperationHandlers(binding);
       binding.add(EMFChangeBoundsOperationHandler.class);
+   }
+
+   @Override
+   protected void configure() {
+      super.configure();
+      configureEMFNotationModelState(bindGModelState());
+   }
+
+   protected void configureEMFNotationModelState(final Class<? extends EMFNotationModelState> modelState) {
+      bind(EMFNotationModelState.class).to(modelState).in(Singleton.class);
    }
 
 }

--- a/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/notation/EMFNotationModelState.java
+++ b/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/notation/EMFNotationModelState.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020 EclipseSource and others.
+ * Copyright (c) 2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/notation/EMFNotationModelState.java
+++ b/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/notation/EMFNotationModelState.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022 EclipseSource and others.
+ * Copyright (c) 2020 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,62 +17,25 @@ package org.eclipse.glsp.server.emf.notation;
 
 import java.util.Optional;
 
-import org.eclipse.emf.common.command.CommandStack;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.glsp.graph.GModelIndex;
-import org.eclipse.glsp.graph.GModelRoot;
-import org.eclipse.glsp.server.emf.EMFModelIndex;
 import org.eclipse.glsp.server.emf.EMFModelState;
 import org.eclipse.glsp.server.emf.model.notation.Diagram;
-import org.eclipse.glsp.server.session.ClientSession;
-import org.eclipse.glsp.server.session.ClientSessionListener;
 
-import com.google.inject.Inject;
+public interface EMFNotationModelState extends EMFModelState {
 
-/**
- * This state represents the status of the diagram based on the {@link GModelRoot}, contains the {@link EMFModelIndex},
- * is able to execute commands via its {@link CommandStack} and is registered as {@link ClientSessionListener}
- * to be able to reset the EMF resources on diagram close.
- *
- * This model state assumes that there is a single semantic root element and a single notation element.
- */
-public class EMFNotationModelState extends EMFModelState {
+   <T extends Diagram> Optional<T> getNotationModel(final Class<T> clazz);
 
-   protected Diagram notationModel;
+   Diagram getNotationModel();
 
-   protected EObject semanticModel;
+   void setNotationModel(final Diagram notationModel);
 
-   @Inject
-   protected EMFSemanticIdConverter semanticIdConverter;
+   <T extends EObject> Optional<T> getSemanticModel(final Class<T> clazz);
+
+   EObject getSemanticModel();
+
+   void setSemanticModel(final EObject semanticModel);
 
    @Override
-   protected GModelIndex getOrUpdateIndex(final GModelRoot newRoot) {
-      return EMFNotationModelIndex.getOrCreate(getRoot(), semanticIdConverter);
-   }
+   EMFNotationModelIndex getIndex();
 
-   @Override
-   public EMFNotationModelIndex getIndex() { return (EMFNotationModelIndex) super.getIndex(); }
-
-   public void setSemanticModel(final EObject semanticModel) { this.semanticModel = semanticModel; }
-
-   public EObject getSemanticModel() { return this.semanticModel; }
-
-   public <T extends EObject> Optional<T> getSemanticModel(final Class<T> clazz) {
-      return Optional.ofNullable(this.semanticModel).filter(clazz::isInstance).map(clazz::cast);
-   }
-
-   public void setNotationModel(final Diagram notationModel) { this.notationModel = notationModel; }
-
-   public Diagram getNotationModel() { return this.notationModel; }
-
-   public <T extends Diagram> Optional<T> getNotationModel(final Class<T> clazz) {
-      return Optional.ofNullable(this.notationModel).filter(clazz::isInstance).map(clazz::cast);
-   }
-
-   @Override
-   public void sessionDisposed(final ClientSession clientSession) {
-      this.semanticModel = null;
-      this.notationModel = null;
-      super.sessionDisposed(clientSession);
-   }
 }

--- a/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/notation/EMFNotationModelState.java
+++ b/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/notation/EMFNotationModelState.java
@@ -23,17 +23,17 @@ import org.eclipse.glsp.server.emf.model.notation.Diagram;
 
 public interface EMFNotationModelState extends EMFModelState {
 
-   <T extends Diagram> Optional<T> getNotationModel(final Class<T> clazz);
+   <T extends Diagram> Optional<T> getNotationModel(Class<T> clazz);
 
    Diagram getNotationModel();
 
-   void setNotationModel(final Diagram notationModel);
+   void setNotationModel(Diagram notationModel);
 
-   <T extends EObject> Optional<T> getSemanticModel(final Class<T> clazz);
+   <T extends EObject> Optional<T> getSemanticModel(Class<T> clazz);
 
    EObject getSemanticModel();
 
-   void setSemanticModel(final EObject semanticModel);
+   void setSemanticModel(EObject semanticModel);
 
    @Override
    EMFNotationModelIndex getIndex();

--- a/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/notation/EMFNotationModelStateImpl.java
+++ b/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/notation/EMFNotationModelStateImpl.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022 EclipseSource and others.
+ * Copyright (c) 2022-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/notation/EMFNotationModelStateImpl.java
+++ b/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/notation/EMFNotationModelStateImpl.java
@@ -28,6 +28,7 @@ import org.eclipse.glsp.server.session.ClientSession;
 import org.eclipse.glsp.server.session.ClientSessionListener;
 
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 
 /**
  * This state represents the status of the diagram based on the {@link GModelRoot}, contains the {@link EMFModelIndex},
@@ -36,6 +37,7 @@ import com.google.inject.Inject;
  *
  * This model state assumes that there is a single semantic root element and a single notation element.
  */
+@Singleton
 public class EMFNotationModelStateImpl extends EMFModelStateImpl
    implements EMFNotationModelState {
 

--- a/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/notation/EMFNotationModelStateImpl.java
+++ b/plugins/org.eclipse.glsp.server.emf/src/org/eclipse/glsp/server/emf/notation/EMFNotationModelStateImpl.java
@@ -1,0 +1,85 @@
+/********************************************************************************
+ * Copyright (c) 2022 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.server.emf.notation;
+
+import java.util.Optional;
+
+import org.eclipse.emf.common.command.CommandStack;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.glsp.graph.GModelIndex;
+import org.eclipse.glsp.graph.GModelRoot;
+import org.eclipse.glsp.server.emf.EMFModelIndex;
+import org.eclipse.glsp.server.emf.EMFModelStateImpl;
+import org.eclipse.glsp.server.emf.model.notation.Diagram;
+import org.eclipse.glsp.server.session.ClientSession;
+import org.eclipse.glsp.server.session.ClientSessionListener;
+
+import com.google.inject.Inject;
+
+/**
+ * This state represents the status of the diagram based on the {@link GModelRoot}, contains the {@link EMFModelIndex},
+ * is able to execute commands via its {@link CommandStack} and is registered as {@link ClientSessionListener}
+ * to be able to reset the EMF resources on diagram close.
+ *
+ * This model state assumes that there is a single semantic root element and a single notation element.
+ */
+public class EMFNotationModelStateImpl extends EMFModelStateImpl
+   implements EMFNotationModelState {
+
+   protected Diagram notationModel;
+
+   protected EObject semanticModel;
+
+   @Inject
+   protected EMFSemanticIdConverter semanticIdConverter;
+
+   @Override
+   protected GModelIndex getOrUpdateIndex(final GModelRoot newRoot) {
+      return EMFNotationModelIndex.getOrCreate(getRoot(), semanticIdConverter);
+   }
+
+   @Override
+   public EMFNotationModelIndex getIndex() { return (EMFNotationModelIndex) super.getIndex(); }
+
+   @Override
+   public void setSemanticModel(final EObject semanticModel) { this.semanticModel = semanticModel; }
+
+   @Override
+   public EObject getSemanticModel() { return this.semanticModel; }
+
+   @Override
+   public <T extends EObject> Optional<T> getSemanticModel(final Class<T> clazz) {
+      return Optional.ofNullable(this.semanticModel).filter(clazz::isInstance).map(clazz::cast);
+   }
+
+   @Override
+   public void setNotationModel(final Diagram notationModel) { this.notationModel = notationModel; }
+
+   @Override
+   public Diagram getNotationModel() { return this.notationModel; }
+
+   @Override
+   public <T extends Diagram> Optional<T> getNotationModel(final Class<T> clazz) {
+      return Optional.ofNullable(this.notationModel).filter(clazz::isInstance).map(clazz::cast);
+   }
+
+   @Override
+   public void sessionDisposed(final ClientSession clientSession) {
+      this.semanticModel = null;
+      this.notationModel = null;
+      super.sessionDisposed(clientSession);
+   }
+}

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/model/DefaultGModelState.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/model/DefaultGModelState.java
@@ -28,7 +28,9 @@ import org.eclipse.glsp.server.di.ClientId;
 import org.eclipse.glsp.server.internal.gmodel.commandstack.GModelCommandStack;
 
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 
+@Singleton
 public class DefaultGModelState implements GModelState {
 
    @Inject
@@ -41,6 +43,10 @@ public class DefaultGModelState implements GModelState {
    protected CommandStack commandStack;
    protected String editMode;
    protected GModelIndex index = GModelIndex.empty();
+
+   public DefaultGModelState() {
+      System.err.println("Instantiate Model State " + getClass().getName());
+   }
 
    @Inject
    public void init() {

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/model/DefaultGModelState.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/model/DefaultGModelState.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2021 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -43,10 +43,6 @@ public class DefaultGModelState implements GModelState {
    protected CommandStack commandStack;
    protected String editMode;
    protected GModelIndex index = GModelIndex.empty();
-
-   public DefaultGModelState() {
-      System.err.println("Instantiate Model State " + getClass().getName());
-   }
 
    @Inject
    public void init() {


### PR DESCRIPTION
- Use interfaces for EMFModelState and EMFNotationModelState
- Use these interfaces for binding and injection

refs https://github.com/eclipse-glsp/glsp/issues/974 