### PR TITLE
GLSP-991: Switch Jenkins build to Java 17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent any
     tools {
         maven 'apache-maven-latest'
-        jdk 'openjdk-jdk11-latest'
+        jdk 'openjdk-jdk17-latest'
     }
 
     environment {
@@ -73,6 +73,11 @@ pipeline {
                             sh 'mvn clean deploy -Pm2 -Pm2-release -Pfatjar  -B -pl "!tests,!tests/org.eclipse.glsp.server.test,!tests/org.eclipse.glsp.graph.test"'
                         }
                      }
+                }
+                stage('Trigger Java11 build') {
+                    steps {
+                        build wait: false, job: 'glsp-server-java11'
+                    }
                 }
             }
         }

--- a/examples/org.eclipse.glsp.example.workflow/pom.xml
+++ b/examples/org.eclipse.glsp.example.workflow/pom.xml
@@ -140,6 +140,7 @@
 							<artifactSet>
 								<excludes>
 									<exclude>jakarta.websocket:jakarta.websocket-api</exclude>
+									<exclude>javax.websocket:javax.websocket-api</exclude>
 									<exclude>log4j:log4j</exclude>
 								</excludes>
 							</artifactSet>
@@ -151,6 +152,7 @@
 										<exclude>META-INF/DEPENDENCIES</exclude>
 										<exclude>META-INF/ECLIPSE_*</exclude>
 										<exclude>META-INF/LICENSE*</exclude>
+										<exclude>META-INF/services/javax.servlet.ServletContainerInitializer</exclude>
 										<exclude>META-INF/services/jakarta.servlet.ServletContainerInitializer*</exclude>
 										<exclude>META-INF/services/org.eclipse.jetty.webapp.Configuration*</exclude>
 										<exclude>META-INF/services/org.eclipse.elk.core.data.ILayoutMetaDataProvider*</exclude>

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/ClientId.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/ClientId.java
@@ -23,7 +23,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import javax.inject.Qualifier;
+import com.google.inject.BindingAnnotation;
 
 /**
  * Helper annotation that is used for injecting the client id string into classes of diagram session (client session)
@@ -37,7 +37,7 @@ import javax.inject.Qualifier;
  * private String diagramType;
  * </pre>
  */
-@Qualifier
 @Target({ FIELD, PARAMETER, METHOD })
 @Retention(RUNTIME)
+@BindingAnnotation
 public @interface ClientId {}

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/DiagramType.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/DiagramType.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021-2022 EclipseSource and others.
+ * Copyright (c) 2021-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -23,7 +23,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import javax.inject.Qualifier;
+import com.google.inject.BindingAnnotation;
 
 /**
  * Helper annotation that is used for injecting the diagram type string into classes of diagram session (client session)
@@ -38,7 +38,7 @@ import javax.inject.Qualifier;
  * </pre>
  *
  */
-@Qualifier
 @Target({ FIELD, PARAMETER, METHOD })
 @Retention(RUNTIME)
+@BindingAnnotation
 public @interface DiagramType {}

--- a/pom.xml
+++ b/pom.xml
@@ -297,11 +297,6 @@
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-source-plugin</artifactId>
 						<version>${maven.source.version}</version>
-						<configuration>
-							<argLine>
-								--illegal-access=permit
-							</argLine>
-						</configuration>
 						<executions>
 							<execution>
 								<id>attach-sources</id>
@@ -316,21 +311,11 @@
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-surefire-plugin</artifactId>
 						<version>${maven.surefire.version}</version>
-						<configuration>
-							<argLine>
-								--illegal-access=permit
-							</argLine>
-						</configuration>
 					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-failsafe-plugin</artifactId>
 						<version>${maven.failsafe.version}</version>
-						<configuration>
-							<argLine>
-								--illegal-access=permit
-							</argLine>
-						</configuration>
 					</plugin>
 					<!-- to disable use -Dcheckstyle.skip -->
 					<plugin>


### PR DESCRIPTION
- Remove direct dependency to javax.inject by switching to google.inject counterparts
 Due to the namespace switch from javax->jakarta with Java17 it's otherwise hard to maintain a build that works for both 11 and 17.
- Remove `illegal-access=permit" flag from plugin configuration as it is no longer supported in Java17 
- Update maven-shade plugin config to get rid of warnings 
- Introduce a new orthogonal Java11 compatibility build job that is triggered for every master commit

Fixes https://github.com/eclipse-glsp/glsp/issues/991