### PR TITLE
GLSP-77: Allow WebSocket connections to reconnect after interrupt

### DIFF
--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/features/core/model/RequestModelActionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/features/core/model/RequestModelActionHandler.java
@@ -70,16 +70,7 @@ public class RequestModelActionHandler extends AbstractActionHandler<RequestMode
 
       ProgressMonitor monitor = notifyStartLoading();
       if (isReconnecting) {
-         GModelRoot oldModel = modelState.getRoot();
-         if (oldModel != null) {
-            // use current modelRoot of modelState and submit
-            modelState.updateRoot(oldModel);
-            // decrease revision by one, as each submit will increase it by one;
-            // the next save would produce warning that source model was changed otherwise
-            modelState.getRoot().setRevision(oldModel.getRevision() - 1);
-         } else {
-            sourceModelStorage.loadSourceModel(action);
-         }
+         handleReconnect(action);
       } else {
          sourceModelStorage.loadSourceModel(action);
       }
@@ -90,6 +81,17 @@ public class RequestModelActionHandler extends AbstractActionHandler<RequestMode
       }
 
       return modelSubmissionHandler.submitModel();
+   }
+
+   protected void handleReconnect(final RequestModelAction action) {
+      GModelRoot oldModel = modelState.getRoot();
+      if (oldModel != null) {
+         // decrease revision by one, as each submit will increase it by one;
+         // the next save would produce warning that source model was changed otherwise
+         modelState.getRoot().setRevision(oldModel.getRevision() - 1);
+      } else {
+         sourceModelStorage.loadSourceModel(action);
+      }
    }
 
    protected ProgressMonitor notifyStartLoading() {

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/utils/ClientOptionsUtil.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/utils/ClientOptionsUtil.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2021 EclipseSource and others.
+ * Copyright (c) 2019-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -25,6 +25,7 @@ import java.util.Optional;
 public final class ClientOptionsUtil {
    public static final String DIAGRAM_TYPE = "diagramType";
    public static final String SOURCE_URI = "sourceUri";
+   public static final String IS_RECONNECTING = "isReconnecting";
    private static final String FILE_PREFIX = "file://";
 
    private ClientOptionsUtil() {}
@@ -35,11 +36,14 @@ public final class ClientOptionsUtil {
 
    public static Optional<String> getDiagramType(final Map<String, String> options) {
       return MapUtil.getValue(options, DIAGRAM_TYPE);
-
    }
 
    public static Optional<File> getSourceUriAsFile(final Map<String, String> options) {
       return MapUtil.getValue(options, SOURCE_URI).map(ClientOptionsUtil::getAsFile);
+   }
+
+   public static Boolean isReconnecting(final Map<String, String> options) {
+      return MapUtil.getBoolValue(options, IS_RECONNECTING);
    }
 
    public static String adaptUri(final String uri) {


### PR DESCRIPTION
If Websocket connections reconnect after an interrupt, ensure that the last modelState is restored on RequestModelAction if available

Part of https://github.com/eclipse-glsp/glsp/issues/77

---

Related to: https://github.com/eclipse-glsp/glsp-client/pull/269
https://github.com/eclipse-glsp/glsp-server-node/pull/54