### PR TITLE
GLSP-1127: Fix publish build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,9 +74,9 @@ pipeline {
                         }
                      }
                 }
-                stage('Trigger Java11 build') {
+                stage('Trigger Java21 build') {
                     steps {
-                        build wait: false, job: 'glsp-server-java11'
+                        build wait: false, job: 'glsp-server-java21'
                     }
                 }
             }

--- a/releng/org.eclipse.glsp.repository/pom.xml
+++ b/releng/org.eclipse.glsp.repository/pom.xml
@@ -95,7 +95,7 @@
 						<artifactId>tycho-eclipserun-plugin</artifactId>
 						<version>${tycho.version}</version>
 						<configuration>
-							<executionEnvironment>JavaSE-17</executionEnvironment>
+							<executionEnvironment>JavaSE-11</executionEnvironment>
 							<!-- IMPORTANT: DO NOT split the arg line -->
 							<appArgLine>-application org.eclipse.ant.core.antRunner -buildfile packaging-p2composite.ant p2.composite.add -Dsite.label=${p2.site.label} -Dproject.build.directory=${project.build.directory} -DunqualifiedVersion=${unqualifiedVersion} -DbuildQualifier=${buildQualifier} -Dsoftware.download.area=${rsync.local.dir}</appArgLine>
 							<repositories>


### PR DESCRIPTION
The tycho-ant-run task for creating the composite update site seems to break with Java17. Since this task is just creating the update site the Java version is not really relevant so for now we switch back to 11. Update jenkins file to trigger Java21 compatibility when on master merges.