### PR TITLE
Fixes eclipse-glsp/glsp#1212

### DIFF
--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/internal/actions/DefaultActionDispatcher.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/internal/actions/DefaultActionDispatcher.java
@@ -199,9 +199,9 @@ public class DefaultActionDispatcher extends Disposable implements ActionDispatc
             .map(response -> ResponseAction.respond(action, response))
             .collect(Collectors.toList());
          results.addAll(dispatchAll(responses));
-         if (action instanceof UpdateModelAction) {
-            results.add(dispatchPostUpdateQueue());
-         }
+      }
+      if (action instanceof UpdateModelAction) {
+         results.add(dispatchPostUpdateQueue());
       }
       return results;
    }


### PR DESCRIPTION
Always execute post update queue even if there is no handler for the UpdateModelAction