### PR TITLE
GLSP-1213 Fix ELK version to 0.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 			platform in ,2. We try to match the p2-version if possible. -->
 		<apache.logging.log4j.version>[2.19.0,)</apache.logging.log4j.version>
 		<commons.cli.version>[1.4,)</commons.cli.version>
-		<elk.version>[0.8.1,)</elk.version>
+		<elk.version>0.8.1</elk.version>
 		<emf.common.version>[2.23.0,)</emf.common.version>
 		<emf.ecore.change.version>[2.14.0,)</emf.ecore.change.version>
 		<emf.ecore.edit.version>[2.13.0,)</emf.ecore.edit.version>


### PR DESCRIPTION
Set ELK version to 0.8.1 in m2 build until https://github.com/eclipse-glsp/glsp/issues/1213 is resolved.