### PR TITLE
Fix log4j version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,12 +37,12 @@
 	</scm>
 
 	<properties>
-	
+
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.source>17</java.source>
 		<java.target>17</java.target>
 		<project.build.java.target>17</project.build.java.target>
-		
+
 		<!-- Maven Plugin Versions: General maven plugin versions -->
 		<buildhelper.maven.version>3.3.0</buildhelper.maven.version>
 		<codehaus.mojo.maven.version>3.2.0</codehaus.mojo.maven.version>
@@ -65,7 +65,7 @@
 
 		<!-- Dependency Versions: Version of dependencies provided by the target 
 			platform in ,2. We try to match the p2-version if possible. -->
-		<apache.logging.log4j.version>[2.19.0,)</apache.logging.log4j.version>
+		<apache.logging.log4j.version>[2.19.0,2.23.1]</apache.logging.log4j.version>
 		<commons.cli.version>[1.4,)</commons.cli.version>
 		<elk.version>0.8.1</elk.version>
 		<emf.common.version>[2.23.0,)</emf.common.version>
@@ -81,7 +81,7 @@
 		<lsp4j.version>[0.11.0,)</lsp4j.version>
 		<jetty.websocket.version>[10.0.12,)</jetty.websocket.version>
 
-		
+
 		<!-- Release Dependencies for M2 -->
 		<nexus.maven.version>1.6.13</nexus.maven.version>
 		<maven.gpg.version>1.6</maven.gpg.version>
@@ -119,8 +119,8 @@
 			</activation>
 
 			<properties>
-			  <!-- Maven Plugin Versions: General maven plugin versions -->
-				
+				<!-- Maven Plugin Versions: General maven plugin versions -->
+
 			</properties>
 
 			<modules>
@@ -255,7 +255,7 @@
 			</activation>
 
 			<properties>
-				<checkstyle.version>8.44</checkstyle.version>		
+				<checkstyle.version>8.44</checkstyle.version>
 			</properties>
 
 			<modules>
@@ -267,7 +267,7 @@
 				<module>examples/org.eclipse.glsp.example.workflow</module>
 				<module>tests</module>
 			</modules>
-			
+
 			<dependencies>
 				<dependency>
 					<groupId>org.apache.logging.log4j</groupId>
@@ -280,9 +280,9 @@
 					<version>${google.guava.version}</version>
 				</dependency>
 				<dependency>
-				    <groupId>org.apache.logging.log4j</groupId>
-				    <artifactId>log4j-slf4j2-impl</artifactId>
-				    <version>${apache.logging.log4j.version}</version>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-slf4j2-impl</artifactId>
+					<version>${apache.logging.log4j.version}</version>
 				</dependency>
 			</dependencies>
 
@@ -364,7 +364,7 @@
 				<module>plugins/org.eclipse.glsp.server.websocket</module>
 				<module>examples/org.eclipse.glsp.example.workflow</module>
 			</modules>
-			
+
 
 			<distributionManagement>
 				<snapshotRepository>
@@ -392,7 +392,7 @@
 						<artifactId>maven-javadoc-plugin</artifactId>
 						<version>${maven.javadoc.version}</version>
 						<configuration>
-						
+
 							<source>${java.source}</source>
 							<detectJavaApiLink>false</detectJavaApiLink>
 							<tags>


### PR DESCRIPTION
#### What it does

The error was caused by maven that used log4j with the version `3.0.0-beta`. 
The targetplatform uses `2.19.0` - now we are limiting the version of log4j to be in range of `2.19.0` <= x <= `2.23.1` for maven. We probably also should limit the rest of the dependencies.

~Moreover, I was not able to use the build the project with Eclipse IDE and had to change the location of `jetty` within the targetplatform.~ *Fixed by installing PDE M2 Integration* 

Closes https://github.com/eclipse-glsp/glsp/issues/1312

#### How to test

Run the following command in the root folder:

`mvn clean verify -Pm2 -Pfatjar && java -jar ./examples/org.eclipse.glsp.example.workflow/target/org.eclipse.glsp.example.workflow-2.1.0-glsp.jar -p 8081 -w`

The following error should not be thrown anymore:

```
Exception in thread "main" java.lang.ExceptionInInitializerError
	at org.eclipse.glsp.example.workflow.launch.WorkflowServerLauncher.main(WorkflowServerLauncher.java:35)
Caused by: org.apache.logging.log4j.plugins.di.NotInjectableException: No @Inject constructor or default constructor found for chain Key[type: org.apache.logging.log4j.core.lookup.InterpolatorFactory] -> Key[type: java.util.Map<java.lang.String, java.util.function.Supplier<org.apache.logging.log4j.core.lookup.StrLookup>>; namespace: Lookup]
	at org.apache.logging.log4j.plugins.di.DefaultInstanceFactory.createDefaultFactory(DefaultInstanceFactory.java:133)
	at org.apache.logging.log4j.plugins.di.DefaultInstanceFactory.lambda$getFactory$3(DefaultInstanceFactory.java:111)
	at java.base/java.util.Optional.orElseGet(Optional.java:364)
	at org.apache.logging.log4j.plugins.di.DefaultInstanceFactory.getFactory(DefaultInstanceFactory.java:111)
	at org.apache.logging.log4j.plugins.di.InstanceFactory.getInstance(InstanceFactory.java:126)
	at org.apache.logging.log4j.plugins.di.DefaultInstanceFactory.lambda$getArgumentFactory$9(DefaultInstanceFactory.java:211)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575)
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:622)
	at org.apache.logging.log4j.plugins.di.DefaultInstanceFactory.lambda$registerBundleMethod$13(DefaultInstanceFactory.java:293)
	at org.apache.logging.log4j.plugins.di.InstanceFactory.getInstance(InstanceFactory.java:115)
	at org.apache.logging.log4j.core.config.AbstractConfiguration.<init>(AbstractConfiguration.java:185)
	at org.apache.logging.log4j.core.config.DefaultConfiguration.<init>(DefaultConfiguration.java:41)
	at org.apache.logging.log4j.core.LoggerContext.<init>(LoggerContext.java:89)
	at org.apache.logging.log4j.core.selector.ClassLoaderContextSelector.createContext(ClassLoaderContextSelector.java:289)
	at org.apache.logging.log4j.core.selector.ClassLoaderContextSelector.locateContext(ClassLoaderContextSelector.java:240)
	at org.apache.logging.log4j.core.selector.ClassLoaderContextSelector.getContext(ClassLoaderContextSelector.java:148)
	at org.apache.logging.log4j.core.selector.ClassLoaderContextSelector.getContext(ClassLoaderContextSelector.java:131)
	at org.apache.logging.log4j.core.selector.ClassLoaderContextSelector.getContext(ClassLoaderContextSelector.java:125)
	at org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:156)
	at org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:49)
	at org.apache.logging.log4j.LogManager.getContext(LogManager.java:127)
	at org.apache.logging.log4j.LogManager.getLogger(LogManager.java:554)
	at org.eclipse.glsp.server.launch.CLIParser.<clinit>(CLIParser.java:29)
	... 1 more
```

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [ ] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
