### PR TITLE
Configure fork and join nodes as not resizable

### DIFF
--- a/examples/org.eclipse.glsp.example.workflow/src/org/eclipse/glsp/example/workflow/WorkflowDiagramConfiguration.java
+++ b/examples/org.eclipse.glsp.example.workflow/src/org/eclipse/glsp/example/workflow/WorkflowDiagramConfiguration.java
@@ -68,14 +68,18 @@ public class WorkflowDiagramConfiguration extends BaseDiagramConfiguration {
    @Override
    public List<ShapeTypeHint> getShapeTypeHints() {
       List<ShapeTypeHint> nodeHints = new ArrayList<>();
-      nodeHints.add(new ShapeTypeHint(MANUAL_TASK, true, true, true, true));
-      nodeHints.add(new ShapeTypeHint(AUTOMATED_TASK, true, true, true, true));
-      ShapeTypeHint catHint = new ShapeTypeHint(CATEGORY, true, true, true, true);
+      nodeHints.add(createDefaultShapeTypeHint(MANUAL_TASK));
+      nodeHints.add(createDefaultShapeTypeHint(AUTOMATED_TASK));
+      ShapeTypeHint catHint = createDefaultShapeTypeHint(CATEGORY);
       catHint.setContainableElementTypeIds(
          Arrays.asList(TASK, ACTIVITY_NODE, CATEGORY));
       nodeHints.add(catHint);
-      nodeHints.add(createDefaultShapeTypeHint(FORK_NODE));
-      nodeHints.add(createDefaultShapeTypeHint(JOIN_NODE));
+      ShapeTypeHint forkHint = createDefaultShapeTypeHint(FORK_NODE);
+      forkHint.setResizable(false);
+      nodeHints.add(forkHint);
+      ShapeTypeHint joinHint = createDefaultShapeTypeHint(JOIN_NODE);
+      joinHint.setResizable(false);
+      nodeHints.add(joinHint);
       nodeHints.add(createDefaultShapeTypeHint(DECISION_NODE));
       nodeHints.add(createDefaultShapeTypeHint(MERGE_NODE));
       return nodeHints;


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Update type hints configuration for workflow example to make fork and join nodes not resizable => we have test cases for both resizable and non-resizable elements in the diagram#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [ ] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
