### PR TITLE
GLSP-1398: Properly configure default types

### DIFF
--- a/plugins/org.eclipse.glsp.graph/model/glsp-graph.ecore
+++ b/plugins/org.eclipse.glsp.graph/model/glsp-graph.ecore
@@ -136,4 +136,7 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="resizeLocations" upperBound="-1"
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="GForeignObjectElement" eSuperTypes="#//GShapePreRenderedElement">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="namespace" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+  </eClassifiers>
 </ecore:EPackage>

--- a/plugins/org.eclipse.glsp.graph/model/glsp-graph.genmodel
+++ b/plugins/org.eclipse.glsp.graph/model/glsp-graph.genmodel
@@ -108,5 +108,8 @@
     <genClasses ecoreClass="glsp-graph.ecore#//GResizable">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EAttribute glsp-graph.ecore#//GResizable/resizeLocations"/>
     </genClasses>
+    <genClasses ecoreClass="glsp-graph.ecore#//GForeignObjectElement">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute glsp-graph.ecore#//GForeignObjectElement/namespace"/>
+    </genClasses>
   </genPackages>
 </genmodel:GenModel>

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/GForeignObjectElement.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/GForeignObjectElement.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2019-2022 EclipseSource and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * ********************************************************************************
+ */
+package org.eclipse.glsp.graph;
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the model object '<em><b>GForeign Object Element</b></em>'.
+ * <!-- end-user-doc -->
+ *
+ * <p>
+ * The following features are supported:
+ * </p>
+ * <ul>
+ *   <li>{@link org.eclipse.glsp.graph.GForeignObjectElement#getNamespace <em>Namespace</em>}</li>
+ * </ul>
+ *
+ * @see org.eclipse.glsp.graph.GraphPackage#getGForeignObjectElement()
+ * @model
+ * @generated
+ */
+public interface GForeignObjectElement extends GShapePreRenderedElement {
+   /**
+    * Returns the value of the '<em><b>Namespace</b></em>' attribute.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @return the value of the '<em>Namespace</em>' attribute.
+    * @see #setNamespace(String)
+    * @see org.eclipse.glsp.graph.GraphPackage#getGForeignObjectElement_Namespace()
+    * @model
+    * @generated
+    */
+   String getNamespace();
+
+   /**
+    * Sets the value of the '{@link org.eclipse.glsp.graph.GForeignObjectElement#getNamespace <em>Namespace</em>}' attribute.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @param value the new value of the '<em>Namespace</em>' attribute.
+    * @see #getNamespace()
+    * @generated
+    */
+   void setNamespace(String value);
+
+} // GForeignObjectElement

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/GraphFactory.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/GraphFactory.java
@@ -225,6 +225,15 @@ public interface GraphFactory extends EFactory {
    GResizable createGResizable();
 
    /**
+    * Returns a new object of class '<em>GForeign Object Element</em>'.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @return a new object of class '<em>GForeign Object Element</em>'.
+    * @generated
+    */
+   GForeignObjectElement createGForeignObjectElement();
+
+   /**
     * Returns the package supported by this factory.
     * <!-- begin-user-doc -->
     * <!-- end-user-doc -->

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/GraphPackage.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/GraphPackage.java
@@ -2439,6 +2439,133 @@ public interface GraphPackage extends EPackage {
    int GRESIZABLE_OPERATION_COUNT = 0;
 
    /**
+    * The meta object id for the '{@link org.eclipse.glsp.graph.impl.GForeignObjectElementImpl <em>GForeign Object Element</em>}' class.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @see org.eclipse.glsp.graph.impl.GForeignObjectElementImpl
+    * @see org.eclipse.glsp.graph.impl.GraphPackageImpl#getGForeignObjectElement()
+    * @generated
+    */
+   int GFOREIGN_OBJECT_ELEMENT = 27;
+
+   /**
+    * The feature id for the '<em><b>Args</b></em>' map.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    * @ordered
+    */
+   int GFOREIGN_OBJECT_ELEMENT__ARGS = GSHAPE_PRE_RENDERED_ELEMENT__ARGS;
+
+   /**
+   	 * The feature id for the '<em><b>Id</b></em>' attribute.
+   	 * <!-- begin-user-doc -->
+   	 * <!-- end-user-doc -->
+   	 * @generated
+   	 * @ordered
+   	 */
+   int GFOREIGN_OBJECT_ELEMENT__ID = GSHAPE_PRE_RENDERED_ELEMENT__ID;
+
+   /**
+   	 * The feature id for the '<em><b>Css Classes</b></em>' attribute list.
+   	 * <!-- begin-user-doc -->
+   	 * <!-- end-user-doc -->
+   	 * @generated
+   	 * @ordered
+   	 */
+   int GFOREIGN_OBJECT_ELEMENT__CSS_CLASSES = GSHAPE_PRE_RENDERED_ELEMENT__CSS_CLASSES;
+
+   /**
+   	 * The feature id for the '<em><b>Children</b></em>' containment reference list.
+   	 * <!-- begin-user-doc -->
+   	 * <!-- end-user-doc -->
+   	 * @generated
+   	 * @ordered
+   	 */
+   int GFOREIGN_OBJECT_ELEMENT__CHILDREN = GSHAPE_PRE_RENDERED_ELEMENT__CHILDREN;
+
+   /**
+   	 * The feature id for the '<em><b>Parent</b></em>' container reference.
+   	 * <!-- begin-user-doc -->
+   	 * <!-- end-user-doc -->
+   	 * @generated
+   	 * @ordered
+   	 */
+   int GFOREIGN_OBJECT_ELEMENT__PARENT = GSHAPE_PRE_RENDERED_ELEMENT__PARENT;
+
+   /**
+   	 * The feature id for the '<em><b>Trace</b></em>' attribute.
+   	 * <!-- begin-user-doc -->
+   	 * <!-- end-user-doc -->
+   	 * @generated
+   	 * @ordered
+   	 */
+   int GFOREIGN_OBJECT_ELEMENT__TRACE = GSHAPE_PRE_RENDERED_ELEMENT__TRACE;
+
+   /**
+   	 * The feature id for the '<em><b>Type</b></em>' attribute.
+   	 * <!-- begin-user-doc -->
+   	 * <!-- end-user-doc -->
+   	 * @generated
+   	 * @ordered
+   	 */
+   int GFOREIGN_OBJECT_ELEMENT__TYPE = GSHAPE_PRE_RENDERED_ELEMENT__TYPE;
+
+   /**
+   	 * The feature id for the '<em><b>Code</b></em>' attribute.
+   	 * <!-- begin-user-doc -->
+   	 * <!-- end-user-doc -->
+   	 * @generated
+   	 * @ordered
+   	 */
+   int GFOREIGN_OBJECT_ELEMENT__CODE = GSHAPE_PRE_RENDERED_ELEMENT__CODE;
+
+   /**
+   	 * The feature id for the '<em><b>Position</b></em>' containment reference.
+   	 * <!-- begin-user-doc -->
+   	 * <!-- end-user-doc -->
+   	 * @generated
+   	 * @ordered
+   	 */
+   int GFOREIGN_OBJECT_ELEMENT__POSITION = GSHAPE_PRE_RENDERED_ELEMENT__POSITION;
+
+   /**
+   	 * The feature id for the '<em><b>Size</b></em>' containment reference.
+   	 * <!-- begin-user-doc -->
+   	 * <!-- end-user-doc -->
+   	 * @generated
+   	 * @ordered
+   	 */
+   int GFOREIGN_OBJECT_ELEMENT__SIZE = GSHAPE_PRE_RENDERED_ELEMENT__SIZE;
+
+   /**
+   	 * The feature id for the '<em><b>Namespace</b></em>' attribute.
+   	 * <!-- begin-user-doc -->
+   	 * <!-- end-user-doc -->
+   	 * @generated
+   	 * @ordered
+   	 */
+   int GFOREIGN_OBJECT_ELEMENT__NAMESPACE = GSHAPE_PRE_RENDERED_ELEMENT_FEATURE_COUNT + 0;
+
+   /**
+    * The number of structural features of the '<em>GForeign Object Element</em>' class.
+    * <!-- begin-user-doc -->
+   	 * <!-- end-user-doc -->
+    * @generated
+    * @ordered
+    */
+   int GFOREIGN_OBJECT_ELEMENT_FEATURE_COUNT = GSHAPE_PRE_RENDERED_ELEMENT_FEATURE_COUNT + 1;
+
+   /**
+    * The number of operations of the '<em>GForeign Object Element</em>' class.
+    * <!-- begin-user-doc -->
+   	 * <!-- end-user-doc -->
+    * @generated
+    * @ordered
+    */
+   int GFOREIGN_OBJECT_ELEMENT_OPERATION_COUNT = GSHAPE_PRE_RENDERED_ELEMENT_OPERATION_COUNT + 0;
+
+   /**
     * The meta object id for the '{@link org.eclipse.glsp.graph.GSeverity <em>GSeverity</em>}' enum.
     * <!-- begin-user-doc -->
     * <!-- end-user-doc -->
@@ -2446,7 +2573,7 @@ public interface GraphPackage extends EPackage {
     * @see org.eclipse.glsp.graph.impl.GraphPackageImpl#getGSeverity()
     * @generated
     */
-   int GSEVERITY = 27;
+   int GSEVERITY = 28;
 
    /**
     * Returns the meta object for class '{@link org.eclipse.glsp.graph.GModelElement <em>GModel Element</em>}'.
@@ -3194,6 +3321,27 @@ public interface GraphPackage extends EPackage {
    EAttribute getGResizable_ResizeLocations();
 
    /**
+    * Returns the meta object for class '{@link org.eclipse.glsp.graph.GForeignObjectElement <em>GForeign Object Element</em>}'.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @return the meta object for class '<em>GForeign Object Element</em>'.
+    * @see org.eclipse.glsp.graph.GForeignObjectElement
+    * @generated
+    */
+   EClass getGForeignObjectElement();
+
+   /**
+    * Returns the meta object for the attribute '{@link org.eclipse.glsp.graph.GForeignObjectElement#getNamespace <em>Namespace</em>}'.
+    * <!-- begin-user-doc -->
+   	 * <!-- end-user-doc -->
+    * @return the meta object for the attribute '<em>Namespace</em>'.
+    * @see org.eclipse.glsp.graph.GForeignObjectElement#getNamespace()
+    * @see #getGForeignObjectElement()
+    * @generated
+    */
+   EAttribute getGForeignObjectElement_Namespace();
+
+   /**
     * Returns the meta object for enum '{@link org.eclipse.glsp.graph.GSeverity <em>GSeverity</em>}'.
     * <!-- begin-user-doc -->
     * <!-- end-user-doc -->
@@ -3839,6 +3987,24 @@ public interface GraphPackage extends EPackage {
        * @generated
        */
       EAttribute GRESIZABLE__RESIZE_LOCATIONS = eINSTANCE.getGResizable_ResizeLocations();
+
+      /**
+       * The meta object literal for the '{@link org.eclipse.glsp.graph.impl.GForeignObjectElementImpl <em>GForeign Object Element</em>}' class.
+       * <!-- begin-user-doc -->
+       * <!-- end-user-doc -->
+       * @see org.eclipse.glsp.graph.impl.GForeignObjectElementImpl
+       * @see org.eclipse.glsp.graph.impl.GraphPackageImpl#getGForeignObjectElement()
+       * @generated
+       */
+      EClass GFOREIGN_OBJECT_ELEMENT = eINSTANCE.getGForeignObjectElement();
+
+      /**
+       * The meta object literal for the '<em><b>Namespace</b></em>' attribute feature.
+       * <!-- begin-user-doc -->
+      	 * <!-- end-user-doc -->
+       * @generated
+       */
+      EAttribute GFOREIGN_OBJECT_ELEMENT__NAMESPACE = eINSTANCE.getGForeignObjectElement_Namespace();
 
       /**
        * The meta object literal for the '{@link org.eclipse.glsp.graph.GSeverity <em>GSeverity</em>}' enum.

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GForeignObjectElementImpl.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GForeignObjectElementImpl.java
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) 2019-2022 EclipseSource and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * ********************************************************************************
+ */
+package org.eclipse.glsp.graph.impl;
+
+import org.eclipse.emf.common.notify.Notification;
+
+import org.eclipse.emf.ecore.EClass;
+
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
+import org.eclipse.glsp.graph.GForeignObjectElement;
+import org.eclipse.glsp.graph.GraphPackage;
+
+/**
+ * <!-- begin-user-doc -->
+ * An implementation of the model object '<em><b>GForeign Object Element</b></em>'.
+ * <!-- end-user-doc -->
+ * <p>
+ * The following features are implemented:
+ * </p>
+ * <ul>
+ *   <li>{@link org.eclipse.glsp.graph.impl.GForeignObjectElementImpl#getNamespace <em>Namespace</em>}</li>
+ * </ul>
+ *
+ * @generated
+ */
+public class GForeignObjectElementImpl extends GShapePreRenderedElementImpl implements GForeignObjectElement {
+   /**
+    * The default value of the '{@link #getNamespace() <em>Namespace</em>}' attribute.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @see #getNamespace()
+    * @generated
+    * @ordered
+    */
+   protected static final String NAMESPACE_EDEFAULT = null;
+
+   /**
+    * The cached value of the '{@link #getNamespace() <em>Namespace</em>}' attribute.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @see #getNamespace()
+    * @generated
+    * @ordered
+    */
+   protected String namespace = NAMESPACE_EDEFAULT;
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   public GForeignObjectElementImpl() {
+      super();
+   }
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   @Override
+   protected EClass eStaticClass() {
+      return GraphPackage.Literals.GFOREIGN_OBJECT_ELEMENT;
+   }
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   @Override
+   public String getNamespace() { return namespace; }
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   @Override
+   public void setNamespace(String newNamespace) {
+      String oldNamespace = namespace;
+      namespace = newNamespace;
+      if (eNotificationRequired())
+         eNotify(new ENotificationImpl(this, Notification.SET, GraphPackage.GFOREIGN_OBJECT_ELEMENT__NAMESPACE,
+            oldNamespace, namespace));
+   }
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   @Override
+   public Object eGet(int featureID, boolean resolve, boolean coreType) {
+      switch (featureID) {
+         case GraphPackage.GFOREIGN_OBJECT_ELEMENT__NAMESPACE:
+            return getNamespace();
+      }
+      return super.eGet(featureID, resolve, coreType);
+   }
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   @Override
+   public void eSet(int featureID, Object newValue) {
+      switch (featureID) {
+         case GraphPackage.GFOREIGN_OBJECT_ELEMENT__NAMESPACE:
+            setNamespace((String) newValue);
+            return;
+      }
+      super.eSet(featureID, newValue);
+   }
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   @Override
+   public void eUnset(int featureID) {
+      switch (featureID) {
+         case GraphPackage.GFOREIGN_OBJECT_ELEMENT__NAMESPACE:
+            setNamespace(NAMESPACE_EDEFAULT);
+            return;
+      }
+      super.eUnset(featureID);
+   }
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   @Override
+   public boolean eIsSet(int featureID) {
+      switch (featureID) {
+         case GraphPackage.GFOREIGN_OBJECT_ELEMENT__NAMESPACE:
+            return NAMESPACE_EDEFAULT == null ? namespace != null : !NAMESPACE_EDEFAULT.equals(namespace);
+      }
+      return super.eIsSet(featureID);
+   }
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   @Override
+   public String toString() {
+      if (eIsProxy())
+         return super.toString();
+
+      StringBuilder result = new StringBuilder(super.toString());
+      result.append(" (namespace: ");
+      result.append(namespace);
+      result.append(')');
+      return result.toString();
+   }
+
+} //GForeignObjectElementImpl

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GraphFactoryImpl.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GraphFactoryImpl.java
@@ -116,6 +116,8 @@ public class GraphFactoryImpl extends EFactoryImpl implements GraphFactory {
             return createGLayoutable();
          case GraphPackage.GRESIZABLE:
             return createGResizable();
+         case GraphPackage.GFOREIGN_OBJECT_ELEMENT:
+            return createGForeignObjectElement();
          default:
             throw new IllegalArgumentException("The class '" + eClass.getName() + "' is not a valid classifier");
       }
@@ -390,6 +392,17 @@ public class GraphFactoryImpl extends EFactoryImpl implements GraphFactory {
    public GResizable createGResizable() {
       GResizableImpl gResizable = new GResizableImpl();
       return gResizable;
+   }
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   @Override
+   public GForeignObjectElement createGForeignObjectElement() {
+      GForeignObjectElementImpl gForeignObjectElement = new GForeignObjectElementImpl();
+      return gForeignObjectElement;
    }
 
    /**

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GraphPackageImpl.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/impl/GraphPackageImpl.java
@@ -36,6 +36,7 @@ import org.eclipse.glsp.graph.GDimension;
 import org.eclipse.glsp.graph.GEdge;
 import org.eclipse.glsp.graph.GEdgeLayoutable;
 import org.eclipse.glsp.graph.GEdgePlacement;
+import org.eclipse.glsp.graph.GForeignObjectElement;
 import org.eclipse.glsp.graph.GGraph;
 import org.eclipse.glsp.graph.GHtmlRoot;
 import org.eclipse.glsp.graph.GIssue;
@@ -251,6 +252,13 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
     * @generated
     */
    private EClass gResizableEClass = null;
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   private EClass gForeignObjectElementEClass = null;
 
    /**
     * <!-- begin-user-doc -->
@@ -927,6 +935,24 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
     * @generated
     */
    @Override
+   public EClass getGForeignObjectElement() { return gForeignObjectElementEClass; }
+
+   /**
+    * <!-- begin-user-doc -->
+   	 * <!-- end-user-doc -->
+    * @generated
+    */
+   @Override
+   public EAttribute getGForeignObjectElement_Namespace() {
+      return (EAttribute) gForeignObjectElementEClass.getEStructuralFeatures().get(0);
+   }
+
+   /**
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @generated
+    */
+   @Override
    public EEnum getGSeverity() { return gSeverityEEnum; }
 
    /**
@@ -1054,6 +1080,9 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
       gResizableEClass = createEClass(GRESIZABLE);
       createEAttribute(gResizableEClass, GRESIZABLE__RESIZE_LOCATIONS);
 
+      gForeignObjectElementEClass = createEClass(GFOREIGN_OBJECT_ELEMENT);
+      createEAttribute(gForeignObjectElementEClass, GFOREIGN_OBJECT_ELEMENT__NAMESPACE);
+
       // Create enums
       gSeverityEEnum = createEEnum(GSEVERITY);
    }
@@ -1113,6 +1142,7 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
       gPreRenderedElementEClass.getESuperTypes().add(this.getGModelElement());
       gShapePreRenderedElementEClass.getESuperTypes().add(this.getGPreRenderedElement());
       gShapePreRenderedElementEClass.getESuperTypes().add(this.getGBoundsAware());
+      gForeignObjectElementEClass.getESuperTypes().add(this.getGShapePreRenderedElement());
 
       // Initialize classes, features, and operations; add parameters
       initEClass(gModelElementEClass, GModelElement.class, "GModelElement", IS_ABSTRACT, IS_INTERFACE,
@@ -1291,6 +1321,12 @@ public class GraphPackageImpl extends EPackageImpl implements GraphPackage {
       initEAttribute(getGResizable_ResizeLocations(), ecorePackage.getEString(), "resizeLocations", null, 0, -1,
          GResizable.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED,
          IS_ORDERED);
+
+      initEClass(gForeignObjectElementEClass, GForeignObjectElement.class, "GForeignObjectElement", !IS_ABSTRACT,
+         !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+      initEAttribute(getGForeignObjectElement_Namespace(), ecorePackage.getEString(), "namespace", null, 0, 1,
+         GForeignObjectElement.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
+         !IS_DERIVED, IS_ORDERED);
 
       // Initialize enums and add enum literals
       initEEnum(gSeverityEEnum, GSeverity.class, "GSeverity");

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/util/GraphAdapterFactory.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/util/GraphAdapterFactory.java
@@ -218,6 +218,11 @@ public class GraphAdapterFactory extends AdapterFactoryImpl {
       }
 
       @Override
+      public Adapter caseGForeignObjectElement(GForeignObjectElement object) {
+         return createGForeignObjectElementAdapter();
+      }
+
+      @Override
       public Adapter defaultCase(EObject object) {
          return createEObjectAdapter();
       }
@@ -611,6 +616,20 @@ public class GraphAdapterFactory extends AdapterFactoryImpl {
     * @generated
     */
    public Adapter createGResizableAdapter() {
+      return null;
+   }
+
+   /**
+    * Creates a new adapter for an object of class '{@link org.eclipse.glsp.graph.GForeignObjectElement <em>GForeign Object Element</em>}'.
+    * <!-- begin-user-doc -->
+    * This default implementation returns null so that we can easily ignore cases;
+    * it's useful to ignore a case when inheritance will catch all the cases anyway.
+    * <!-- end-user-doc -->
+    * @return the new adapter.
+    * @see org.eclipse.glsp.graph.GForeignObjectElement
+    * @generated
+    */
+   public Adapter createGForeignObjectElementAdapter() {
       return null;
    }
 

--- a/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/util/GraphSwitch.java
+++ b/plugins/org.eclipse.glsp.graph/src-gen/org/eclipse/glsp/graph/util/GraphSwitch.java
@@ -404,6 +404,23 @@ public class GraphSwitch<T> extends Switch<T> {
                result = defaultCase(theEObject);
             return result;
          }
+         case GraphPackage.GFOREIGN_OBJECT_ELEMENT: {
+            GForeignObjectElement gForeignObjectElement = (GForeignObjectElement) theEObject;
+            T result = caseGForeignObjectElement(gForeignObjectElement);
+            if (result == null)
+               result = caseGShapePreRenderedElement(gForeignObjectElement);
+            if (result == null)
+               result = caseGPreRenderedElement(gForeignObjectElement);
+            if (result == null)
+               result = caseGBoundsAware(gForeignObjectElement);
+            if (result == null)
+               result = caseGModelElement(gForeignObjectElement);
+            if (result == null)
+               result = caseGArgumentable(gForeignObjectElement);
+            if (result == null)
+               result = defaultCase(theEObject);
+            return result;
+         }
          default:
             return defaultCase(theEObject);
       }
@@ -811,6 +828,21 @@ public class GraphSwitch<T> extends Switch<T> {
     * @generated
     */
    public T caseGResizable(GResizable object) {
+      return null;
+   }
+
+   /**
+    * Returns the result of interpreting the object as an instance of '<em>GForeign Object Element</em>'.
+    * <!-- begin-user-doc -->
+    * This implementation returns null;
+    * returning a non-null result will terminate the switch.
+    * <!-- end-user-doc -->
+    * @param object the target of the switch.
+    * @return the result of interpreting the object as an instance of '<em>GForeign Object Element</em>'.
+    * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+    * @generated
+    */
+   public T caseGForeignObjectElement(GForeignObjectElement object) {
       return null;
    }
 

--- a/plugins/org.eclipse.glsp.graph/src/org/eclipse/glsp/graph/DefaultTypes.java
+++ b/plugins/org.eclipse.glsp.graph/src/org/eclipse/glsp/graph/DefaultTypes.java
@@ -33,21 +33,22 @@ public final class DefaultTypes {
    public static final String COMPARTMENT_HEADER = "comp:header";
    public static final String BUTTON = "button";
    public static final String EXPAND_BUTTON = "button:expand";
-   public static final String ISSUE_MARKER = "marker";
 
    // shapes
    public static final String NODE_CIRCLE = "node:circle";
    public static final String NODE_RECTANGLE = "node:rectangle";
    public static final String NODE_DIAMOND = "node:diamond";
+   public static final String FOREIGN_OBJECT = "foreign-object";
+   public static final String PRE_RENDERED = "pre-rendered";
+   public static final String SHAPE_PRE_RENDERED = "shape-pre-rendered";
+
+   public static final String HTML = "html";
 
    // types present on the client
    public static final String ROUTING_POINT = "routing-point";
    public static final String VOLATILE_ROUTING_POINT = "volatile-routing-point";
-   public static final String HTML = "html";
-   public static final String FOREIGN_OBJECT = "foreign-object";
-   public static final String PRE_RENDERED = "pre-rendered";
-   public static final String SHAPE_PRE_RENDERED = "shape-pre-rendered";
    public static final String SVG = "svg";
+   public static final String ISSUE_MARKER = "marker";
 
    public static Map<String, EClass> getDefaultTypeMappings() {
       Map<String, EClass> mapping = new HashMap<>();
@@ -57,14 +58,13 @@ public final class DefaultTypes {
       mapping.put(PORT, GraphPackage.Literals.GPORT);
       mapping.put(LABEL, GraphPackage.Literals.GLABEL);
       mapping.put(COMPARTMENT, GraphPackage.Literals.GCOMPARTMENT);
-      mapping.put(COMPARTMENT_HEADER, GraphPackage.Literals.GCOMPARTMENT);
       mapping.put(BUTTON, GraphPackage.Literals.GBUTTON);
-      mapping.put(EXPAND_BUTTON, GraphPackage.Literals.GBUTTON);
       mapping.put(ISSUE_MARKER, GraphPackage.Literals.GISSUE_MARKER);
 
-      mapping.put(NODE_CIRCLE, GraphPackage.Literals.GNODE);
-      mapping.put(NODE_RECTANGLE, GraphPackage.Literals.GNODE);
-      mapping.put(NODE_DIAMOND, GraphPackage.Literals.GNODE);
+      mapping.put(HTML, GraphPackage.Literals.GHTML_ROOT);
+      mapping.put(PRE_RENDERED, GraphPackage.Literals.GPRE_RENDERED_ELEMENT);
+      mapping.put(SHAPE_PRE_RENDERED, GraphPackage.Literals.GSHAPE_PRE_RENDERED_ELEMENT);
+      mapping.put(FOREIGN_OBJECT, GraphPackage.Literals.GFOREIGN_OBJECT_ELEMENT);
       return mapping;
    }
 }

--- a/plugins/org.eclipse.glsp.graph/src/org/eclipse/glsp/graph/builder/AbstractGForeignObjectBuilder.java
+++ b/plugins/org.eclipse.glsp.graph/src/org/eclipse/glsp/graph/builder/AbstractGForeignObjectBuilder.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022 EclipseSource and others.
+ * Copyright (c) 2024 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,32 +13,27 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-package org.eclipse.glsp.graph.builder.impl;
+package org.eclipse.glsp.graph.builder;
 
-import org.eclipse.glsp.graph.DefaultTypes;
-import org.eclipse.glsp.graph.GShapePreRenderedElement;
-import org.eclipse.glsp.graph.GraphFactory;
-import org.eclipse.glsp.graph.builder.AbstractGShapePrenderedElementBuilder;
+import org.eclipse.glsp.graph.GForeignObjectElement;
 
-public class GShapePrerenderedElementBuilder
-   extends AbstractGShapePrenderedElementBuilder<GShapePreRenderedElement, GShapePrerenderedElementBuilder> {
+public abstract class AbstractGForeignObjectBuilder<T extends GForeignObjectElement, E extends AbstractGForeignObjectBuilder<T, E>>
+   extends AbstractGShapePrenderedElementBuilder<T, E> {
+   protected String namespace;
 
-   public GShapePrerenderedElementBuilder() {
-      this(DefaultTypes.SHAPE_PRE_RENDERED);
-   }
-
-   public GShapePrerenderedElementBuilder(final String type) {
+   public AbstractGForeignObjectBuilder(final String type) {
       super(type);
    }
 
-   @Override
-   protected GShapePreRenderedElement instantiate() {
-      return GraphFactory.eINSTANCE.createGShapePreRenderedElement();
+   public E namespace(final String namespace) {
+      this.namespace = namespace;
+      return self();
    }
 
    @Override
-   protected GShapePrerenderedElementBuilder self() {
-      return this;
+   protected void setProperties(final T element) {
+      super.setProperties(element);
+      element.setNamespace(namespace);
    }
 
 }

--- a/plugins/org.eclipse.glsp.graph/src/org/eclipse/glsp/graph/builder/impl/GForeignObjectBuilder.java
+++ b/plugins/org.eclipse.glsp.graph/src/org/eclipse/glsp/graph/builder/impl/GForeignObjectBuilder.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022 EclipseSource and others.
+ * Copyright (c) 2024 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,28 +16,27 @@
 package org.eclipse.glsp.graph.builder.impl;
 
 import org.eclipse.glsp.graph.DefaultTypes;
-import org.eclipse.glsp.graph.GShapePreRenderedElement;
+import org.eclipse.glsp.graph.GForeignObjectElement;
 import org.eclipse.glsp.graph.GraphFactory;
-import org.eclipse.glsp.graph.builder.AbstractGShapePrenderedElementBuilder;
+import org.eclipse.glsp.graph.builder.AbstractGForeignObjectBuilder;
 
-public class GShapePrerenderedElementBuilder
-   extends AbstractGShapePrenderedElementBuilder<GShapePreRenderedElement, GShapePrerenderedElementBuilder> {
+public class GForeignObjectBuilder extends AbstractGForeignObjectBuilder<GForeignObjectElement, GForeignObjectBuilder> {
 
-   public GShapePrerenderedElementBuilder() {
-      this(DefaultTypes.SHAPE_PRE_RENDERED);
+   public GForeignObjectBuilder() {
+      this(DefaultTypes.FOREIGN_OBJECT);
    }
 
-   public GShapePrerenderedElementBuilder(final String type) {
+   public GForeignObjectBuilder(final String type) {
       super(type);
    }
 
    @Override
-   protected GShapePreRenderedElement instantiate() {
-      return GraphFactory.eINSTANCE.createGShapePreRenderedElement();
+   protected GForeignObjectElement instantiate() {
+      return GraphFactory.eINSTANCE.createGForeignObjectElement();
    }
 
    @Override
-   protected GShapePrerenderedElementBuilder self() {
+   protected GForeignObjectBuilder self() {
       return this;
    }
 

--- a/plugins/org.eclipse.glsp.graph/src/org/eclipse/glsp/graph/gson/GraphGsonConfigurator.java
+++ b/plugins/org.eclipse.glsp.graph/src/org/eclipse/glsp/graph/gson/GraphGsonConfigurator.java
@@ -15,17 +15,6 @@
  ********************************************************************************/
 package org.eclipse.glsp.graph.gson;
 
-import static org.eclipse.glsp.graph.DefaultTypes.COMPARTMENT;
-import static org.eclipse.glsp.graph.DefaultTypes.EDGE;
-import static org.eclipse.glsp.graph.DefaultTypes.GRAPH;
-import static org.eclipse.glsp.graph.DefaultTypes.LABEL;
-import static org.eclipse.glsp.graph.DefaultTypes.NODE;
-import static org.eclipse.glsp.graph.GraphPackage.Literals.GCOMPARTMENT;
-import static org.eclipse.glsp.graph.GraphPackage.Literals.GEDGE;
-import static org.eclipse.glsp.graph.GraphPackage.Literals.GGRAPH;
-import static org.eclipse.glsp.graph.GraphPackage.Literals.GLABEL;
-import static org.eclipse.glsp.graph.GraphPackage.Literals.GNODE;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -36,6 +25,7 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.glsp.graph.DefaultTypes;
 import org.eclipse.glsp.graph.GraphPackage;
 
 import com.google.gson.GsonBuilder;
@@ -52,13 +42,7 @@ public class GraphGsonConfigurator {
    }
 
    public GraphGsonConfigurator withDefaultTypes() {
-      Map<String, EClass> defaultTypes = new HashMap<>();
-      defaultTypes.put(GRAPH, GGRAPH);
-      defaultTypes.put(NODE, GNODE);
-      defaultTypes.put(EDGE, GEDGE);
-      defaultTypes.put(COMPARTMENT, GCOMPARTMENT);
-      defaultTypes.put(LABEL, GLABEL);
-      return withTypes(defaultTypes);
+      return withTypes(DefaultTypes.getDefaultTypeMappings());
    }
 
    public GraphGsonConfigurator withTypes(final Map<String, EClass> types) {

--- a/tests/org.eclipse.glsp.graph.test/resources/graphWithAllDefaultTypes.graph
+++ b/tests/org.eclipse.glsp.graph.test/resources/graphWithAllDefaultTypes.graph
@@ -1,0 +1,122 @@
+{
+  "revision": 0,
+  "type": "graph",
+  "id": "graphId",
+  "children": [
+    {
+      "id": "edge12",
+      "type": "edge",
+      "sourceId": "node1",
+      "targetId": "node2"
+    },
+    {
+      "id": "node1",
+      "type": "node",
+      "position": {
+        "x": 10.0,
+        "y": 20.0
+      },
+      "children": [
+        {
+          "id": "header",
+          "type": "comp:header",
+          "position": {
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "id": "compartment",
+          "type": "comp",
+          "position": {
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "id": "label",
+          "type": "label",
+          "text": "someLabel",
+          "position": {
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "id": "port",
+          "type": "port",
+          "position": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ]
+    },
+    {
+      "id": "node2",
+      "type": "node:circle",
+      "position": {
+        "x": 30.0,
+        "y": 40.0
+      }
+    },
+    {
+      "id": "node3",
+      "type": "node:rectangle",
+      "position": {
+        "x": 30.0,
+        "y": 40.0
+      }
+    },
+    {
+      "id": "node3",
+      "type": "node:diamond",
+      "position": {
+        "x": 30.0,
+        "y": 40.0
+      }
+    },
+    {
+      "id": "button1",
+      "type": "button",
+      "enabled": true,
+      "position": {
+        "x": 30.0,
+        "y": 40.0
+      }
+    },
+    {
+      "id": "button2",
+      "type": "button:expand",
+      "enabled": false,
+      "position": {
+        "x": 30.0,
+        "y": 40.0
+      }
+    },
+    {
+      "id": "prerendered",
+      "type": "pre-rendered",
+      "code": "<div>some html</div>"
+    },
+    {
+      "id": "shapePrerendered",
+      "type": "shape-pre-rendered",
+      "position": {
+        "x": 30.0,
+        "y": 40.0
+      },
+      "code": "<rect></rect>"
+    },
+    {
+      "id": "foreignObject",
+      "type": "foreign-object",
+      "code": "<div>hello</div>",
+      "position": {
+        "x": 30.0,
+        "y": 40.0
+      },
+      "namespace": "http://www.w3.org/1999/xhtml"
+    }
+  ]
+}

--- a/tests/org.eclipse.glsp.graph.test/src/org/eclipse/glsp/graph/GModelIndexWhenDeserializedFromJsonTest.java
+++ b/tests/org.eclipse.glsp.graph.test/src/org/eclipse/glsp/graph/GModelIndexWhenDeserializedFromJsonTest.java
@@ -22,6 +22,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.Collection;
 
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.glsp.graph.gson.GraphGsonConfigurator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -103,6 +104,34 @@ public class GModelIndexWhenDeserializedFromJsonTest {
       assertEquals(1, incomingEdgesOfNode2.size());
       assertEquals(0, outgoingEdgesOfNode2.size());
       assertTrue(incomingEdgesOfNode2.contains(edge));
+   }
+
+   @Test
+   void testGetAllSvgDefaulTypes() throws IOException {
+      GGraph graph = loadResource("graphWithAllDefaultTypes.graph");
+      EList<GModelElement> children = graph.getChildren();
+      assertType(children.get(0), GEdge.class, DefaultTypes.EDGE);
+      assertType(children.get(1), GNode.class, DefaultTypes.NODE);
+      assertType(children.get(2), GNode.class, DefaultTypes.NODE_CIRCLE);
+      assertType(children.get(3), GNode.class, DefaultTypes.NODE_RECTANGLE);
+      assertType(children.get(4), GNode.class, DefaultTypes.NODE_DIAMOND);
+      assertType(children.get(5), GButton.class, DefaultTypes.BUTTON);
+      assertType(children.get(6), GButton.class, DefaultTypes.EXPAND_BUTTON);
+      assertType(children.get(7), GPreRenderedElement.class, DefaultTypes.PRE_RENDERED);
+      assertType(children.get(8), GShapePreRenderedElement.class, DefaultTypes.SHAPE_PRE_RENDERED);
+      assertType(children.get(9), GForeignObjectElement.class, DefaultTypes.FOREIGN_OBJECT);
+      EList<GModelElement> nodeChidlren = children.get(1).getChildren();
+      assertType(nodeChidlren.get(0), GCompartment.class, DefaultTypes.COMPARTMENT_HEADER);
+      assertType(nodeChidlren.get(1), GCompartment.class, DefaultTypes.COMPARTMENT);
+      assertType(nodeChidlren.get(2), GLabel.class, DefaultTypes.LABEL);
+      assertType(nodeChidlren.get(3), GPort.class, DefaultTypes.PORT);
+
+   }
+
+   private <T extends GModelElement> void assertType(final GModelElement element, final Class<T> clazz,
+      final String type) {
+      assertTrue(clazz.isInstance(element));
+      assertTrue(element.getType().equals(type));
    }
 
    private GGraph loadResource(final String file) throws IOException {


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

- Update graph model to add missing `GForeignObjectElement` and corresponding builder
- Add empty default constructor to `GPreRenderedElementBuilder`
- Update default type mapping configuration
  - Add missing configuration for foreign and shaped prerendered elements
  - Remove redundant registration of subtypes with the same eclass as the parent type
  - Extend deserialization test cases to ensure that all default types are properly deserialized

Fixes https://github.com/eclipse-glsp/glsp/issues/1398
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [ ] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
