### PR TITLE
GLSP-1387 Do not bind DefaultActionDispatcher as ActionHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changes
 
+- [API] Fix: do not bind the DefaultActionDispatcher as ActionHandler, so it can be correctly disposed and the thread is closed at the end of a session [#246](https://github.com/eclipse-glsp/glsp-server/pull/246) - Contributed on behalf of Axon Ivy AG
+
 ### Potentially Breaking Changes
 
 ## [v2.2.1 - 22/07/2024](https://github.com/eclipse-glsp/glsp-server/releases/tag/v2.2.1)

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/DiagramModule.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/di/DiagramModule.java
@@ -261,7 +261,7 @@ public abstract class DiagramModule extends GLSPModule {
    }
 
    protected void configureActionHandlers(final MultiBinding<ActionHandler> binding) {
-      binding.add(DefaultActionDispatcher.class);
+      binding.add(DefaultActionDispatcher.JoinActionHandler.class);
       binding.add(OperationActionHandler.class);
       binding.add(RequestModelActionHandler.class);
       binding.add(RequestPopupModelActionHandler.class);

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/internal/actions/DefaultActionDispatcher.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/internal/actions/DefaultActionDispatcher.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.eclipse.glsp.server.actions.AbstractActionHandler;
 import org.eclipse.glsp.server.actions.Action;
 import org.eclipse.glsp.server.actions.ActionDispatcher;
 import org.eclipse.glsp.server.actions.ActionHandler;
@@ -46,6 +47,7 @@ import org.eclipse.glsp.server.utils.FutureUtil;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
+
 /**
  * <p>
  * An ActionDispatcher that executes all handlers in the same thread. The dispatcher's
@@ -53,7 +55,7 @@ import com.google.inject.Provider;
  * the server.
  * </p>
  */
-public class DefaultActionDispatcher extends Disposable implements ActionDispatcher, ActionHandler {
+public class DefaultActionDispatcher extends Disposable implements ActionDispatcher {
 
    protected static final Logger LOGGER = LogManager.getLogger(DefaultActionDispatcher.class);
 
@@ -246,20 +248,19 @@ public class DefaultActionDispatcher extends Disposable implements ActionDispatc
       }
    }
 
-   @Override
-   public List<Class<? extends Action>> getHandledActionTypes() { return List.of(JoinAction.class); }
-
-   @Override
-   public List<Action> execute(final Action action) {
-      return none();
-   }
-
    /**
     * An internal action class that is used to define a join-point within the queue of all pending actions.
     */
    public static class JoinAction extends Action {
       public JoinAction() {
          super("internal.join");
+      }
+   }
+
+   public static class JoinActionHandler extends AbstractActionHandler<JoinAction> {
+      @Override
+      protected List<Action> executeAction(final JoinAction actualAction) {
+         return none();
       }
    }
 }


### PR DESCRIPTION
#### What it does

Fixes: https://github.com/eclipse-glsp/glsp/issues/1387

Do not register the DefaultActionDispatcher as ActionHandler, instead create a new inner class JoinActionHandler that handles the JoinAction.

#### How to test

See issue

#### Follow-ups



#### Changelog

- [x] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
