### PR TITLE
GLSP-1509: Fix maven build

### DIFF
--- a/examples/org.eclipse.glsp.example.workflow/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.glsp.example.workflow/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GLSP Workflow Example
 Bundle-SymbolicName: org.eclipse.glsp.example.workflow;singleton:=true
-Bundle-Version: 2.5.0.SNAPSHOT
+Bundle-Version: 2.5.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: Eclipse GLSP
 Bundle-Localization: plugin

--- a/examples/org.eclipse.glsp.example.workflow/pom.xml
+++ b/examples/org.eclipse.glsp.example.workflow/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>2.5.0.SNAPSHOT</version>
+		<version>2.5.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/plugins/org.eclipse.glsp.graph/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.graph/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GLSP Graph
 Bundle-SymbolicName: org.eclipse.glsp.graph;singleton:=true
-Bundle-Version: 2.5.0.SNAPSHOT
+Bundle-Version: 2.5.0.qualifier
 Bundle-Vendor: Eclipse GLSP
 Automatic-Module-Name: org.eclipse.glsp.graph
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/plugins/org.eclipse.glsp.graph/pom.xml
+++ b/plugins/org.eclipse.glsp.graph/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>2.5.0.SNAPSHOT</version>
+		<version>2.5.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/plugins/org.eclipse.glsp.graph/src/org/eclipse/glsp/graph/gson/GraphGsonConfigurator.java
+++ b/plugins/org.eclipse.glsp.graph/src/org/eclipse/glsp/graph/gson/GraphGsonConfigurator.java
@@ -21,6 +21,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.emf.common.util.BasicEList;
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EObject;
@@ -29,6 +31,7 @@ import org.eclipse.glsp.graph.DefaultTypes;
 import org.eclipse.glsp.graph.GraphPackage;
 
 import com.google.gson.GsonBuilder;
+import com.google.gson.InstanceCreator;
 
 public class GraphGsonConfigurator {
 
@@ -58,6 +61,7 @@ public class GraphGsonConfigurator {
    public GsonBuilder configureGsonBuilder(final GsonBuilder gsonBuilder) {
       gsonBuilder.registerTypeAdapterFactory(new EMapTypeAdapter.Factory());
       gsonBuilder.registerTypeAdapterFactory(new GModelElementTypeAdapter.Factory(DEFAULT_TYPE_ATT, typeMap));
+      gsonBuilder.registerTypeAdapter(EList.class, (InstanceCreator<EList<?>>) type -> new BasicEList<>());
       configureClassesOfPackages(gsonBuilder);
       gsonBuilder.addSerializationExclusionStrategy(new EObjectExclusionStrategy());
       return gsonBuilder;

--- a/plugins/org.eclipse.glsp.layout/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.layout/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GLSP Layout
 Bundle-SymbolicName: org.eclipse.glsp.layout
-Bundle-Version: 2.5.0.SNAPSHOT
+Bundle-Version: 2.5.0.qualifier
 Bundle-Vendor: EclispeSource
 Automatic-Module-Name: org.eclipse.glsp.layout
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/plugins/org.eclipse.glsp.layout/pom.xml
+++ b/plugins/org.eclipse.glsp.layout/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>2.5.0.SNAPSHOT</version>
+		<version>2.5.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/plugins/org.eclipse.glsp.server.emf/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.server.emf/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GLSP Server EMF
 Bundle-SymbolicName: org.eclipse.glsp.server.emf;singleton:=true
-Bundle-Version: 2.5.0.SNAPSHOT
+Bundle-Version: 2.5.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: Eclipse GLSP
 Bundle-Localization: plugin

--- a/plugins/org.eclipse.glsp.server.emf/pom.xml
+++ b/plugins/org.eclipse.glsp.server.emf/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>2.5.0.SNAPSHOT</version>
+		<version>2.5.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/plugins/org.eclipse.glsp.server.websocket/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.server.websocket/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GLSP Server Websocket
 Bundle-SymbolicName: org.eclipse.glsp.server.websocket
-Bundle-Version: 2.5.0.SNAPSHOT
+Bundle-Version: 2.5.0.qualifier
 Bundle-Vendor: Eclipse GLSP
 Automatic-Module-Name: com.eclipsesource.glps.server.websocket
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/plugins/org.eclipse.glsp.server.websocket/pom.xml
+++ b/plugins/org.eclipse.glsp.server.websocket/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>2.5.0.SNAPSHOT</version>
+		<version>2.5.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/plugins/org.eclipse.glsp.server/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.server/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GLSP Server
 Bundle-SymbolicName: org.eclipse.glsp.server
-Bundle-Version: 2.5.0.SNAPSHOT
+Bundle-Version: 2.5.0.qualifier
 Bundle-Vendor: Eclipse GLSP
 Automatic-Module-Name: org.eclipse.glsp.server
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/plugins/org.eclipse.glsp.server/pom.xml
+++ b/plugins/org.eclipse.glsp.server/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>2.5.0.SNAPSHOT</version>
+		<version>2.5.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>org.eclipse.glsp</groupId>
 	<artifactId>org.eclipse.glsp.parent</artifactId>
 	<description>GLSP Parent pom </description>
-	<version>2.5.0.SNAPSHOT</version>
+	<version>2.5.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>GLSP Parent</name>

--- a/releng/org.eclipse.glsp.feature/feature.xml
+++ b/releng/org.eclipse.glsp.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.glsp.feature"
       label="GLSP SDK (Core)"
-      version="2.5.0.SNAPSHOT"
+      version="2.5.0.qualifier"
       provider-name="Eclipse GLSP">
 
    <description url="http://www.example.com/description">

--- a/releng/org.eclipse.glsp.feature/pom.xml
+++ b/releng/org.eclipse.glsp.feature/pom.xml
@@ -4,7 +4,7 @@
   <parent>
   	<groupId>org.eclipse.glsp</groupId>
   	<artifactId>org.eclipse.glsp.releng</artifactId>
-  	<version>2.5.0.SNAPSHOT</version>
+  	<version>2.5.0-SNAPSHOT</version>
   	<relativePath>../</relativePath>
   </parent>
   <packaging>eclipse-feature</packaging>

--- a/releng/org.eclipse.glsp.repository/pom.xml
+++ b/releng/org.eclipse.glsp.repository/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.releng</artifactId>
-		<version>2.5.0.SNAPSHOT</version>
+		<version>2.5.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 	<artifactId>org.eclipse.glsp.repository</artifactId>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>2.5.0.SNAPSHOT</version>
+		<version>2.5.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/tests/org.eclipse.glsp.graph.test/pom.xml
+++ b/tests/org.eclipse.glsp.graph.test/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>2.5.0.SNAPSHOT</version>
+		<version>2.5.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/tests/org.eclipse.glsp.server.test/pom.xml
+++ b/tests/org.eclipse.glsp.server.test/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>2.5.0.SNAPSHOT</version>
+		<version>2.5.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>2.5.0.SNAPSHOT</version>
+		<version>2.5.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does
- Use correct qualified snapshot version
- Add explicit TypeAdapter for ELists to Graph JSON configurator (required due to a breaking change in GSON 2.13)

P2 build uses 2.11 but m2build can pull in a higher version. 
Nevertheless the fix is straight forward and prevents upgrade pains in the future so its preferrable over pinning
GSON to a version < 2.13.0

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [x] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
