### PR TITLE
feat: add request/response support to server ActionDispatcher

### DIFF
--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/ActionDispatcher.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/ActionDispatcher.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2021 EclipseSource and others.
+ * Copyright (c) 2019-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,9 +15,9 @@
  ********************************************************************************/
 package org.eclipse.glsp.server.actions;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 import org.eclipse.glsp.server.disposable.IDisposable;
 import org.eclipse.glsp.server.features.core.model.UpdateModelAction;
@@ -27,6 +27,12 @@ import org.eclipse.glsp.server.features.core.model.UpdateModelAction;
  * handlers.
  */
 public interface ActionDispatcher extends IDisposable {
+
+   /**
+    * Default timeout in milliseconds applied by {@link #requestUntil(RequestAction)} when neither
+    * a timeout argument nor {@link RequestAction#getTimeout()} provides one.
+    */
+   long DEFAULT_REQUEST_TIMEOUT_MS = 2_000L;
 
    /**
     * <p>
@@ -40,15 +46,21 @@ public interface ActionDispatcher extends IDisposable {
    CompletableFuture<Void> dispatch(Action action);
 
    /**
-    * <p>
-    * Processes all given actions by dispatching to the corresponding handlers.
-    * </p>
+    * Dispatches the given actions sequentially. A failure short-circuits the batch; remaining
+    * actions are not dispatched and their futures complete with the upstream failure.
     *
     * @param actions Actions to dispatch
     * @return A list of {@link CompletableFuture CompletableFutures}; one for each dispatched action
     */
    default List<CompletableFuture<Void>> dispatchAll(final List<Action> actions) {
-      return actions.stream().map(action -> dispatch(action)).collect(Collectors.toList());
+      List<CompletableFuture<Void>> results = new ArrayList<>(actions.size());
+      CompletableFuture<Void> previous = CompletableFuture.completedFuture(null);
+      for (Action action : actions) {
+         CompletableFuture<Void> current = previous.thenCompose(v -> dispatch(action));
+         results.add(current);
+         previous = current;
+      }
+      return results;
    }
 
    /**
@@ -59,4 +71,86 @@ public interface ActionDispatcher extends IDisposable {
     * @param actions The actions that should be dispatched after the next model update
     */
    void dispatchAfterNextUpdate(Action... actions);
+
+   /**
+    * Dispatches a request action and returns a future that completes when a matching response
+    * action is dispatched, or completes exceptionally if the response is a {@link RejectAction}.
+    * The matching response is <em>not</em> passed to registered action handlers; it is the
+    * caller's responsibility to handle the response.
+    *
+    * <p>
+    * If the request's {@code kind} is registered as a client action, it is forwarded to the
+    * client. If server-side handlers are registered for the kind, they are also executed. Only
+    * the first matching response resolves the request; additional or late responses are
+    * dispatched as normal actions.
+    * </p>
+    *
+    * <p>
+    * The returned future never completes by timeout. Use {@link #requestUntil} if a timeout is
+    * needed.
+    * </p>
+    *
+    * <p>
+    * Note: mutates {@code action.requestId} (if unset) and {@code action.timeout}.
+    * </p>
+    *
+    * @param action The request action to dispatch.
+    * @return A future that completes with the matching response action.
+    */
+   default <RES extends ResponseAction> CompletableFuture<RES> request(final RequestAction<RES> action) {
+      throw new UnsupportedOperationException("request() is not implemented by this ActionDispatcher");
+   }
+
+   /**
+    * Dispatches a request using {@link RequestAction#getTimeout} or
+    * {@link #DEFAULT_REQUEST_TIMEOUT_MS} when unset. Soft timeout (no rejection).
+    *
+    * @param action The request action to dispatch.
+    * @return The matching response, or {@code null} on soft timeout.
+    */
+   default <RES extends ResponseAction> CompletableFuture<RES> requestUntil(final RequestAction<RES> action) {
+      Long configured = action.getTimeout();
+      long effective = configured != null ? configured : DEFAULT_REQUEST_TIMEOUT_MS;
+      return requestUntil(action, effective, false);
+   }
+
+   /**
+    * Dispatches a request with the given timeout, completing with {@code null} on timeout
+    * (no exception). Equivalent to
+    * {@link #requestUntil(RequestAction, long, boolean) requestUntil(action, timeoutMs, false)}.
+    *
+    * @param action    The request action to dispatch.
+    * @param timeoutMs Maximum wait time in milliseconds. {@code 0} fires immediately;
+    *                  a negative value disables the timeout (wait indefinitely).
+    * @return The matching response, or {@code null} on soft timeout.
+    */
+   default <RES extends ResponseAction> CompletableFuture<RES> requestUntil(final RequestAction<RES> action,
+      final long timeoutMs) {
+      return requestUntil(action, timeoutMs, false);
+   }
+
+   /**
+    * Dispatches a request and waits for a response until the given timeout is reached. The
+    * returned future completes when a matching response is dispatched, or when the timeout
+    * elapses. The matching response is <em>not</em> passed to registered action handlers.
+    *
+    * <p>
+    * If {@code rejectOnTimeout} is {@code false} the future completes with {@code null} on
+    * timeout; otherwise it completes exceptionally.
+    * </p>
+    *
+    * <p>
+    * Note: mutates {@code action.requestId} (if unset) and {@code action.timeout}.
+    * </p>
+    *
+    * @param action          The request action to dispatch.
+    * @param timeoutMs       Maximum wait time in milliseconds. {@code 0} fires immediately;
+    *                        a negative value disables the timeout (wait indefinitely).
+    * @param rejectOnTimeout Whether to reject the future on timeout.
+    * @return The matching response, or {@code null} on soft timeout.
+    */
+   default <RES extends ResponseAction> CompletableFuture<RES> requestUntil(final RequestAction<RES> action,
+      final long timeoutMs, final boolean rejectOnTimeout) {
+      throw new UnsupportedOperationException("requestUntil() is not implemented by this ActionDispatcher");
+   }
 }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/ActionDispatcher.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/ActionDispatcher.java
@@ -109,8 +109,7 @@ public interface ActionDispatcher extends IDisposable {
     * @return The matching response, or {@code null} on soft timeout.
     */
    default <RES extends ResponseAction> CompletableFuture<RES> requestUntil(final RequestAction<RES> action) {
-      Long configured = action.getTimeout();
-      long effective = configured != null ? configured : DEFAULT_REQUEST_TIMEOUT_MS;
+      long effective = action.getTimeout().orElse(DEFAULT_REQUEST_TIMEOUT_MS);
       return requestUntil(action, effective, false);
    }
 

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/ClientActionForwarder.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/ClientActionForwarder.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020-2023 EclipseSource and others.
+ * Copyright (c) 2020-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -67,7 +67,7 @@ public class ClientActionForwarder {
       if (action.isReceivedFromClient()) {
          return false;
       }
-      return (clientActionKinds.contains(action.getKind()) || action instanceof ResponseAction);
+      return clientActionKinds.contains(action.getKind()) || ResponseAction.hasValidResponseId(action);
    }
 
 }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/RequestAction.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/RequestAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -21,7 +21,8 @@ package org.eclipse.glsp.server.actions;
  * @param <RESPONSE> The type of the {@link ResponseAction}.
  */
 public abstract class RequestAction<RESPONSE extends ResponseAction> extends Action {
-   private final String requestId;
+   private String requestId;
+   private Long timeout;
 
    public RequestAction(final String kind) {
       this(kind, "");
@@ -33,4 +34,13 @@ public abstract class RequestAction<RESPONSE extends ResponseAction> extends Act
    }
 
    public String getRequestId() { return requestId; }
+
+   public void setRequestId(final String requestId) { this.requestId = requestId; }
+
+   /**
+    * Maximum wait time in milliseconds for a response, or {@code null} for no timeout.
+    */
+   public Long getTimeout() { return timeout; }
+
+   public void setTimeout(final Long timeout) { this.timeout = timeout; }
 }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/RequestAction.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/RequestAction.java
@@ -15,6 +15,9 @@
  ******************************************************************************/
 package org.eclipse.glsp.server.actions;
 
+import java.util.Optional;
+import java.util.function.Supplier;
+
 /**
  * An action that expects a response.
  *
@@ -35,12 +38,24 @@ public abstract class RequestAction<RESPONSE extends ResponseAction> extends Act
 
    public String getRequestId() { return requestId; }
 
-   public void setRequestId(final String requestId) { this.requestId = requestId; }
+   /**
+    * Assigns a request id supplied by {@code idGenerator} to the given action if no id has been
+    * set yet. No-op if a non-empty id is already present, so an id assigned at construction is
+    * preserved.
+    *
+    * @param action      the request action to stamp
+    * @param idGenerator supplier invoked only when an id needs to be assigned
+    */
+   public static void ensureRequestId(final RequestAction<?> action, final Supplier<String> idGenerator) {
+      if (action.requestId == null || action.requestId.isEmpty()) {
+         action.requestId = idGenerator.get();
+      }
+   }
 
    /**
-    * Maximum wait time in milliseconds for a response, or {@code null} for no timeout.
+    * Maximum wait time in milliseconds for a response, or {@link Optional#empty()} for no timeout.
     */
-   public Long getTimeout() { return timeout; }
+   public Optional<Long> getTimeout() { return Optional.ofNullable(timeout); }
 
    public void setTimeout(final Long timeout) { this.timeout = timeout; }
 }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/ResponseAction.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/ResponseAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -31,6 +31,21 @@ public class ResponseAction extends Action {
    public String getResponseId() { return responseId; }
 
    public void setResponseId(final String responseId) { this.responseId = responseId; }
+
+   /**
+    * Returns {@code true} if the given action is a {@link ResponseAction} with a non-empty
+    * {@link ResponseAction#responseId responseId}.
+    *
+    * @param action the action to test
+    * @return {@code true} if the action is a {@link ResponseAction} with a valid responseId
+    */
+   public static boolean hasValidResponseId(final Action action) {
+      if (!(action instanceof ResponseAction response)) {
+         return false;
+      }
+      String responseId = response.getResponseId();
+      return responseId != null && !responseId.isEmpty();
+   }
 
    /**
     * Transfers the {@link ResponseAction#responseId id} from request to response if applicable.

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/internal/actions/DefaultActionDispatcher.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/internal/actions/DefaultActionDispatcher.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -24,7 +24,12 @@ import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -36,17 +41,17 @@ import org.eclipse.glsp.server.actions.ActionDispatcher;
 import org.eclipse.glsp.server.actions.ActionHandler;
 import org.eclipse.glsp.server.actions.ActionHandlerRegistry;
 import org.eclipse.glsp.server.actions.ClientActionForwarder;
+import org.eclipse.glsp.server.actions.RejectAction;
+import org.eclipse.glsp.server.actions.RequestAction;
 import org.eclipse.glsp.server.actions.ResponseAction;
 import org.eclipse.glsp.server.di.ClientId;
 import org.eclipse.glsp.server.disposable.Disposable;
 import org.eclipse.glsp.server.features.core.model.SetModelAction;
 import org.eclipse.glsp.server.features.core.model.UpdateModelAction;
-import org.eclipse.glsp.server.protocol.GLSPClient;
+import org.eclipse.glsp.server.types.GLSPServerException;
 import org.eclipse.glsp.server.utils.FutureUtil;
 
 import com.google.inject.Inject;
-import com.google.inject.Provider;
-
 
 /**
  * <p>
@@ -58,6 +63,8 @@ import com.google.inject.Provider;
 public class DefaultActionDispatcher extends Disposable implements ActionDispatcher {
 
    protected static final Logger LOGGER = LogManager.getLogger(DefaultActionDispatcher.class);
+
+   protected static final long STALE_TIMEOUT_GRACE_MS = 30_000L;
 
    private static final AtomicInteger COUNT = new AtomicInteger(0);
 
@@ -77,16 +84,26 @@ public class DefaultActionDispatcher extends Disposable implements ActionDispatc
 
    protected final BlockingQueue<Action> actionsQueue = new ArrayBlockingQueue<>(100, true);
 
-   protected List<Action> postUpdateQueue = new ArrayList<>();
+   // Guarded by postUpdateLock: written from any thread that drains a response.
+   protected final List<Action> postUpdateQueue = new ArrayList<>();
+   protected final Object postUpdateLock = new Object();
 
    // Results will be placed in the map when the action dispatcher receives a new action (From arbitrary threads),
    // and will be removed from the dispatcher's thread.
    protected final Map<Action, CompletableFuture<Void>> results = Collections.synchronizedMap(new HashMap<>());
 
-   // Use a provider, as the GLSPClient is probably not created yet. We won't receive
-   // any action until it's ready anyway.
-   @Inject
-   protected Provider<GLSPClient> client;
+   // Pending server-initiated requests awaiting a matching response. Keyed by requestId.
+   // Accessed from multiple threads (dispatcher thread, JSON-RPC thread, scheduler thread).
+   protected final Map<String, CompletableFuture<? extends ResponseAction>> pendingRequests
+      = new ConcurrentHashMap<>();
+
+   // Active timeout markers per requestId. After the timeout fires the entry is kept briefly as
+   // a stale marker to filter late responses, then cleaned up after STALE_TIMEOUT_GRACE_MS.
+   protected final Map<String, ScheduledFuture<?>> requestTimeouts = new ConcurrentHashMap<>();
+
+   protected final AtomicInteger nextRequestId = new AtomicInteger(1);
+
+   protected ScheduledExecutorService scheduler;
 
    public DefaultActionDispatcher() {
       this.initialize();
@@ -94,13 +111,35 @@ public class DefaultActionDispatcher extends Disposable implements ActionDispatc
 
    protected void initialize() {
       this.name = getClass().getSimpleName() + " " + COUNT.incrementAndGet();
+      this.scheduler = this.createScheduler();
       this.thread = this.createThread();
       this.initializeThread(thread, name);
       thread.start();
    }
 
+   protected String generateRequestId() {
+      return "server_" + clientId + "_" + nextRequestId.getAndIncrement();
+   }
+
+   /**
+    * Grace period in milliseconds during which a stale-timeout marker is retained after a
+    * request times out, so that a slightly late response can still be filtered. Override to
+    * tune; subclasses (notably tests) should keep this short.
+    */
+   protected long getStaleTimeoutGraceMs() {
+      return STALE_TIMEOUT_GRACE_MS;
+   }
+
    protected Thread createThread() {
       return new Thread(this::runThread);
+   }
+
+   protected ScheduledExecutorService createScheduler() {
+      return Executors.newSingleThreadScheduledExecutor(runnable -> {
+         Thread schedulerThread = new Thread(runnable);
+         initializeThread(schedulerThread, name + "-scheduler");
+         return schedulerThread;
+      });
    }
 
    protected void initializeThread(final Thread thread, final String name) {
@@ -110,7 +149,10 @@ public class DefaultActionDispatcher extends Disposable implements ActionDispatc
 
    @Override
    public CompletableFuture<Void> dispatch(final Action action) {
-
+      // Intercept first to avoid deadlock: a handler may be awaiting this response.
+      if (interceptPendingResponse(action)) {
+         return CompletableFuture.completedFuture(null);
+      }
       CompletableFuture<Void> result = new CompletableFuture<>();
       results.put(action, result);
       if (thread == Thread.currentThread()) {
@@ -125,8 +167,89 @@ public class DefaultActionDispatcher extends Disposable implements ActionDispatc
    }
 
    @Override
+   public <RES extends ResponseAction> CompletableFuture<RES> request(final RequestAction<RES> action) {
+      return doRequest(action, null, true);
+   }
+
+   @Override
+   public <RES extends ResponseAction> CompletableFuture<RES> requestUntil(final RequestAction<RES> action,
+      final long timeoutMs, final boolean rejectOnTimeout) {
+      return doRequest(action, timeoutMs >= 0 ? timeoutMs : null, rejectOnTimeout);
+   }
+
+   /**
+    * A handler that calls {@code .get()} or {@code .join()} on the returned future from the
+    * dispatcher thread blocks that thread until the response arrives, holding the action queue
+    * during the wait. This is intentional: the queue's purpose is to serialize handler
+    * execution. Use {@link #requestUntil(RequestAction, long, boolean) requestUntil} with a
+    * positive timeout to bound the wait when the responding side may not reply.
+    *
+    * @param timeoutMs Maximum wait time in milliseconds, or {@code null} to wait indefinitely.
+    */
+   protected <RES extends ResponseAction> CompletableFuture<RES> doRequest(final RequestAction<RES> action,
+      final Long timeoutMs, final boolean rejectOnTimeout) {
+      if (action.getRequestId() == null || action.getRequestId().isEmpty()) {
+         action.setRequestId(generateRequestId());
+      }
+      action.setTimeout(timeoutMs);
+
+      final String requestId = action.getRequestId();
+      final CompletableFuture<RES> deferred = new CompletableFuture<>();
+      pendingRequests.put(requestId, deferred);
+
+      if (timeoutMs != null) {
+         scheduleRequestTimeout(requestId, action.getKind(), timeoutMs, rejectOnTimeout, deferred);
+      }
+
+      // dispatch() routes correctly: external callers queue, dispatcher-thread callers run inline.
+      // The matching response resolves the deferred via interceptPendingResponse().
+      dispatch(action).exceptionally(error -> {
+         failPendingRequest(requestId, error, deferred);
+         return null;
+      });
+
+      return deferred;
+   }
+
+   protected <RES extends ResponseAction> void scheduleRequestTimeout(final String requestId, final String kind,
+      final long timeoutMs, final boolean rejectOnTimeout, final CompletableFuture<RES> deferred) {
+      ScheduledFuture<?> timeout = scheduler.schedule(() -> {
+         if (pendingRequests.remove(requestId) == null) {
+            return;
+         }
+         // Keep the requestTimeouts entry briefly as a stale marker so a late response can be
+         // filtered, then drop it after a grace period to avoid leaking markers for requests
+         // whose late responses never arrive.
+         scheduler.schedule(() -> requestTimeouts.remove(requestId),
+            getStaleTimeoutGraceMs(), TimeUnit.MILLISECONDS);
+         String message = String.format("Request '%s' (%s) timed out after %dms", requestId, kind, timeoutMs);
+         if (rejectOnTimeout) {
+            deferred.completeExceptionally(new TimeoutException(message));
+         } else {
+            LOGGER.info(message);
+            deferred.complete(null);
+         }
+      }, timeoutMs, TimeUnit.MILLISECONDS);
+      requestTimeouts.put(requestId, timeout);
+   }
+
+   protected void failPendingRequest(final String requestId, final Throwable error,
+      final CompletableFuture<?> deferred) {
+      if (pendingRequests.remove(requestId) == null) {
+         return;
+      }
+      ScheduledFuture<?> pendingTimeout = requestTimeouts.remove(requestId);
+      if (pendingTimeout != null) {
+         pendingTimeout.cancel(false);
+      }
+      deferred.completeExceptionally(error);
+   }
+
+   @Override
    public void dispatchAfterNextUpdate(final Action... actions) {
-      postUpdateQueue.addAll(Arrays.asList(actions));
+      synchronized (postUpdateLock) {
+         postUpdateQueue.addAll(Arrays.asList(actions));
+      }
    }
 
    protected void addToQueue(final Action action) {
@@ -222,10 +345,20 @@ public class DefaultActionDispatcher extends Disposable implements ActionDispatc
    }
 
    protected CompletableFuture<Void> dispatchPostUpdateQueue() {
-      ArrayList<Action> toDispatch = new ArrayList<>(postUpdateQueue);
-      postUpdateQueue.clear();
+      List<Action> toDispatch = drainPostUpdateQueue();
       dispatchAll(toDispatch);
       return CompletableFuture.completedFuture(null);
+   }
+
+   protected List<Action> drainPostUpdateQueue() {
+      synchronized (postUpdateLock) {
+         if (postUpdateQueue.isEmpty()) {
+            return Collections.emptyList();
+         }
+         List<Action> drained = new ArrayList<>(postUpdateQueue);
+         postUpdateQueue.clear();
+         return drained;
+      }
    }
 
    protected final void checkThread() {
@@ -235,6 +368,92 @@ public class DefaultActionDispatcher extends Disposable implements ActionDispatc
       }
    }
 
+   /**
+    * Checks whether the given action is a response matching a pending {@link #request} or
+    * {@link #requestUntil} call. If matched, completes (or fails) the corresponding future and
+    * returns {@code true} so the caller can short-circuit normal dispatch.
+    *
+    * <p>
+    * For responses with a populated {@code responseId} but no matching pending request, checks
+    * for a stale timeout marker (timed-out request) and clears the {@code responseId} so the
+    * action is not forwarded by {@link ClientActionForwarder}. If no stale marker exists the
+    * {@code responseId} is left intact for normal forwarding.
+    * </p>
+    */
+   protected boolean interceptPendingResponse(final Action action) {
+      if (!(action instanceof ResponseAction response)) {
+         return false;
+      }
+      String responseId = response.getResponseId();
+      if (responseId == null || responseId.isEmpty()) {
+         return false;
+      }
+      CompletableFuture<? extends ResponseAction> deferred = pendingRequests.remove(responseId);
+      if (deferred != null) {
+         return resolvePendingResponse(deferred, response);
+      }
+      clearStaleMarker(responseId, response);
+      return false;
+   }
+
+   @SuppressWarnings({ "unchecked", "rawtypes" })
+   protected boolean resolvePendingResponse(final CompletableFuture<? extends ResponseAction> deferred,
+      final ResponseAction response) {
+      ScheduledFuture<?> timeout = requestTimeouts.remove(response.getResponseId());
+      if (timeout != null) {
+         timeout.cancel(false);
+      }
+      // Intercepted responses skip handleAction, so drain post-update actions here when the
+      // response is a SetModel. RejectAction does not trigger a drain; pending post-update
+      // actions stay queued until the next successful update.
+      List<Action> postUpdateActions = drainPostUpdateForResponse(response);
+      if (response instanceof RejectAction reject) {
+         String message = reject.getMessage()
+            + reject.getDetail().map(detail -> ": " + detail).orElse("");
+         deferred.completeExceptionally(new GLSPServerException(message));
+      } else {
+         ((CompletableFuture) deferred).complete(response);
+      }
+      if (!postUpdateActions.isEmpty()) {
+         dispatchPostUpdateAfterResponse(postUpdateActions);
+      }
+      return true;
+   }
+
+   protected List<Action> drainPostUpdateForResponse(final ResponseAction response) {
+      if (!(response instanceof SetModelAction)) {
+         return Collections.emptyList();
+      }
+      return drainPostUpdateQueue();
+   }
+
+   /** Fire-and-forget: failures here should not block the request resolution. */
+   protected void dispatchPostUpdateAfterResponse(final List<Action> actions) {
+      List<CompletableFuture<Void>> futures = dispatchAll(actions);
+      if (futures.isEmpty()) {
+         return;
+      }
+      CompletableFuture.allOf(futures.toArray(new CompletableFuture<?>[0]))
+         .exceptionally(ex -> {
+            LOGGER.error("Failed to dispatch post-update actions", ex);
+            return null;
+         });
+   }
+
+   /**
+    * Late response for a timed-out request: clear {@code responseId} so
+    * {@link ClientActionForwarder} does not re-emit it to the client.
+    */
+   protected void clearStaleMarker(final String responseId, final ResponseAction response) {
+      ScheduledFuture<?> staleTimeout = requestTimeouts.remove(responseId);
+      if (staleTimeout == null) {
+         return;
+      }
+      staleTimeout.cancel(false);
+      LOGGER.debug(String.format("Late response for timed-out request '%s', dispatching as normal action", responseId));
+      response.setResponseId("");
+   }
+
    protected void executeAllPendingActions() {
       // block until all pending actions have been executed
       dispatch(new JoinAction()).join();
@@ -242,7 +461,27 @@ public class DefaultActionDispatcher extends Disposable implements ActionDispatc
 
    @Override
    public void doDispose() {
-      executeAllPendingActions();
+      // Cancel pending requests first so any awaiting handler unblocks.
+      pendingRequests.forEach((id, deferred) -> deferred.completeExceptionally(
+         new IllegalStateException("Request '" + id + "' cancelled: dispatcher disposed")));
+      pendingRequests.clear();
+      requestTimeouts.values().forEach(timeout -> timeout.cancel(false));
+      requestTimeouts.clear();
+      if (scheduler != null) {
+         scheduler.shutdownNow();
+      }
+      // Reject queued actions: no further processing should happen after dispose.
+      List<Action> remaining = new ArrayList<>();
+      actionsQueue.drainTo(remaining);
+      remaining.forEach(action -> {
+         CompletableFuture<Void> result = results.remove(action);
+         if (result != null) {
+            result.completeExceptionally(new IllegalStateException("ActionDispatcher disposed"));
+         }
+      });
+      synchronized (postUpdateLock) {
+         postUpdateQueue.clear();
+      }
       if (thread.isAlive()) {
          thread.interrupt();
       }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/internal/actions/DefaultActionDispatcher.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/internal/actions/DefaultActionDispatcher.java
@@ -188,9 +188,7 @@ public class DefaultActionDispatcher extends Disposable implements ActionDispatc
     */
    protected <RES extends ResponseAction> CompletableFuture<RES> doRequest(final RequestAction<RES> action,
       final Long timeoutMs, final boolean rejectOnTimeout) {
-      if (action.getRequestId() == null || action.getRequestId().isEmpty()) {
-         action.setRequestId(generateRequestId());
-      }
+      RequestAction.ensureRequestId(action, this::generateRequestId);
       action.setTimeout(timeoutMs);
 
       final String requestId = action.getRequestId();

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/protocol/DefaultGLSPServer.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/protocol/DefaultGLSPServer.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2025 EclipseSource and others.
+ * Copyright (c) 2019-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -22,13 +22,18 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.function.Function;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.glsp.server.actions.Action;
+import org.eclipse.glsp.server.actions.ActionDispatcher;
 import org.eclipse.glsp.server.actions.ActionMessage;
 import org.eclipse.glsp.server.actions.ActionRegistry;
+import org.eclipse.glsp.server.actions.RejectAction;
+import org.eclipse.glsp.server.actions.RequestAction;
+import org.eclipse.glsp.server.actions.ResponseAction;
 import org.eclipse.glsp.server.session.ClientSession;
 import org.eclipse.glsp.server.session.ClientSessionListener;
 import org.eclipse.glsp.server.session.ClientSessionManager;
@@ -182,11 +187,52 @@ public class DefaultGLSPServer implements GLSPServer, ClientSessionListener {
       try {
          Action action = message.getAction();
          action.setReceivedFromClient(true);
-         clientSessions.get(clientSessionId).getActionDispatcher().dispatch(action)
-            .exceptionally(errorHandler);
+         ActionDispatcher dispatcher = clientSessions.get(clientSessionId).getActionDispatcher();
+         if (action instanceof RequestAction<?>) {
+            handleClientRequest(clientSessionId, (RequestAction<?>) action, dispatcher);
+         } else {
+            dispatcher.dispatch(action).exceptionally(errorHandler);
+         }
       } catch (RuntimeException e) {
          errorHandler.apply(e);
       }
+   }
+
+   /**
+    * Dispatches an inbound client request through the {@link ActionDispatcher}, awaits the
+    * response, and sends it back to the client. Failures are translated to a {@link RejectAction}.
+    */
+   @SuppressWarnings("checkstyle:IllegalCatch")
+   protected void handleClientRequest(final String clientSessionId, final RequestAction<?> action,
+      final ActionDispatcher dispatcher) {
+      Long timeout = action.getTimeout();
+      CompletableFuture<? extends ResponseAction> future = timeout != null
+         ? dispatcher.requestUntil(action, timeout, true)
+         : dispatcher.request(action);
+      future.thenAccept(response -> {
+         if (response != null) {
+            sendResponseToClient(clientSessionId, response);
+         }
+      }).exceptionally(error -> {
+         Throwable cause = error instanceof CompletionException && error.getCause() != null
+            ? error.getCause() : error;
+         String detail = cause != null ? cause.toString() : null;
+         LOGGER.error(String.format("Failed to handle request '%s' (%s): %s",
+            action.getKind(), action.getRequestId(), detail));
+         try {
+            RejectAction reject = new RejectAction(action.getRequestId(),
+               String.format("Failed to handle request '%s' (%s)", action.getKind(), action.getRequestId()),
+               detail);
+            sendResponseToClient(clientSessionId, reject);
+         } catch (Throwable sendError) {
+            LOGGER.error("Failed to send rejection for request '" + action.getRequestId() + "'", sendError);
+         }
+         return null;
+      });
+   }
+
+   protected void sendResponseToClient(final String clientSessionId, final ResponseAction response) {
+      getClient().process(new ActionMessage(clientSessionId, response));
    }
 
    public boolean isInitialized() { return initialized.isDone(); }

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/protocol/DefaultGLSPServer.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/protocol/DefaultGLSPServer.java
@@ -20,6 +20,7 @@ import static org.eclipse.glsp.server.utils.MessageActionUtil.error;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -205,9 +206,9 @@ public class DefaultGLSPServer implements GLSPServer, ClientSessionListener {
    @SuppressWarnings("checkstyle:IllegalCatch")
    protected void handleClientRequest(final String clientSessionId, final RequestAction<?> action,
       final ActionDispatcher dispatcher) {
-      Long timeout = action.getTimeout();
-      CompletableFuture<? extends ResponseAction> future = timeout != null
-         ? dispatcher.requestUntil(action, timeout, true)
+      Optional<Long> timeout = action.getTimeout();
+      CompletableFuture<? extends ResponseAction> future = timeout.isPresent()
+         ? dispatcher.requestUntil(action, timeout.get(), true)
          : dispatcher.request(action);
       future.thenAccept(response -> {
          if (response != null) {

--- a/tests/org.eclipse.glsp.server.test/src/org/eclipse/glsp/server/internal/actions/DefaultActionDispatcherTest.java
+++ b/tests/org.eclipse.glsp.server.test/src/org/eclipse/glsp/server/internal/actions/DefaultActionDispatcherTest.java
@@ -1,0 +1,542 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.server.internal.actions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import org.eclipse.glsp.server.actions.Action;
+import org.eclipse.glsp.server.actions.ActionHandler;
+import org.eclipse.glsp.server.actions.ActionHandlerRegistry;
+import org.eclipse.glsp.server.actions.ClientActionForwarder;
+import org.eclipse.glsp.server.actions.RejectAction;
+import org.eclipse.glsp.server.actions.RequestAction;
+import org.eclipse.glsp.server.actions.ResponseAction;
+import org.eclipse.glsp.server.features.core.model.SetModelAction;
+import org.eclipse.glsp.server.types.GLSPServerException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings({ "checkstyle:IllegalThrows", "checkstyle:IllegalCatch", "checkstyle:VisibilityModifier" })
+class DefaultActionDispatcherTest {
+
+   private static final long AWAIT_MS = 1_000L;
+
+   private DefaultActionDispatcher dispatcher;
+   private StubForwarder forwarder;
+   private MapHandlerRegistry registry;
+
+   @BeforeEach
+   void setUp() {
+      dispatcher = new DefaultActionDispatcher();
+      dispatcher.clientId = "test";
+      registry = new MapHandlerRegistry();
+      dispatcher.actionHandlerRegistry = registry;
+      forwarder = new StubForwarder();
+      dispatcher.clientActionForwarder = forwarder;
+   }
+
+   @AfterEach
+   void tearDown() {
+      // Restore default in case a test toggled the forwarder off.
+      forwarder.shouldHandle = true;
+      dispatcher.dispose();
+   }
+
+   // -----------------------------------------------------------------------
+   // ID generation, request stamping
+   // -----------------------------------------------------------------------
+
+   @Test
+   void generateRequestIdProducesServerPrefixedId() {
+      assertEquals("server_test_1", dispatcher.generateRequestId());
+      assertEquals("server_test_2", dispatcher.generateRequestId());
+   }
+
+   @Test
+   void requestStampsRequestIdWhenUnset() {
+      TestRequest request = new TestRequest();
+      assertEquals("", request.getRequestId());
+
+      dispatcher.request(request);
+
+      assertNotNull(request.getRequestId());
+      assertTrue(request.getRequestId().startsWith("server_test_"));
+   }
+
+   @Test
+   void requestKeepsExistingRequestId() {
+      TestRequest request = new TestRequest("preset-id");
+
+      dispatcher.request(request);
+
+      assertEquals("preset-id", request.getRequestId());
+   }
+
+   @Test
+   void requestUntilStampsTimeoutOnAction() {
+      TestRequest request = new TestRequest();
+
+      dispatcher.requestUntil(request, 1234L, false);
+
+      assertEquals(1234L, request.getTimeout());
+   }
+
+   // -----------------------------------------------------------------------
+   // Request / response correlation
+   // -----------------------------------------------------------------------
+
+   @Test
+   void requestResolvesWithMatchingResponse() throws Exception {
+      TestRequest request = new TestRequest();
+      CompletableFuture<TestResponse> future = dispatcher.request(request);
+
+      TestResponse response = new TestResponse(request.getRequestId());
+      dispatcher.dispatch(response);
+
+      assertEquals(response, future.get(AWAIT_MS, TimeUnit.MILLISECONDS));
+   }
+
+   @Test
+   void requestRejectsOnRejectAction() {
+      TestRequest request = new TestRequest();
+      CompletableFuture<TestResponse> future = dispatcher.request(request);
+
+      RejectAction reject = new RejectAction(request.getRequestId(), "boom", "details");
+      dispatcher.dispatch(reject);
+
+      ExecutionException error = assertThrows(ExecutionException.class,
+         () -> future.get(AWAIT_MS, TimeUnit.MILLISECONDS));
+      assertInstanceOf(GLSPServerException.class, error.getCause());
+      assertTrue(error.getCause().getMessage().contains("boom"));
+      assertTrue(error.getCause().getMessage().contains("details"));
+   }
+
+   @Test
+   void multiplePendingRequestsResolveIndependently() throws Exception {
+      TestRequest r1 = new TestRequest();
+      TestRequest r2 = new TestRequest();
+      CompletableFuture<TestResponse> f1 = dispatcher.request(r1);
+      CompletableFuture<TestResponse> f2 = dispatcher.request(r2);
+
+      // Respond to r2 first; r1 should stay pending.
+      TestResponse resp2 = new TestResponse(r2.getRequestId());
+      dispatcher.dispatch(resp2);
+      assertEquals(resp2, f2.get(AWAIT_MS, TimeUnit.MILLISECONDS));
+      assertFalse(f1.isDone());
+
+      TestResponse resp1 = new TestResponse(r1.getRequestId());
+      dispatcher.dispatch(resp1);
+      assertEquals(resp1, f1.get(AWAIT_MS, TimeUnit.MILLISECONDS));
+   }
+
+   @Test
+   void reentrantRequestFromHandlerCorrelatesResponse() throws Exception {
+      AtomicReference<TestResponse> innerResponse = new AtomicReference<>();
+      AtomicReference<Throwable> innerError = new AtomicReference<>();
+
+      registry.register(TriggerAction.class, new ActionHandler() {
+         @Override
+         public List<Class<? extends Action>> getHandledActionTypes() {
+            return List.of(TriggerAction.class);
+         }
+
+         @Override
+         public List<Action> execute(final Action action) {
+            TestRequest req = new TestRequest();
+            CompletableFuture<TestResponse> future = dispatcher.request(req);
+            // Dispatch the matching response from another thread so the dispatcher thread can
+            // unblock via interceptPendingResponse. The pending future is already registered by
+            // request() so a race-free completion is safe regardless of when this thread runs.
+            new Thread(() -> dispatcher.dispatch(new TestResponse(req.getRequestId()))).start();
+            try {
+               innerResponse.set(future.get(AWAIT_MS, TimeUnit.MILLISECONDS));
+            } catch (Exception ex) {
+               innerError.set(ex);
+            }
+            return List.of();
+         }
+      });
+
+      dispatcher.dispatch(new TriggerAction()).get(AWAIT_MS, TimeUnit.MILLISECONDS);
+
+      assertNull(innerError.get());
+      assertNotNull(innerResponse.get());
+   }
+
+   // -----------------------------------------------------------------------
+   // Timeouts and stale markers
+   // -----------------------------------------------------------------------
+
+   @Test
+   void requestUntilRejectsOnHardTimeout() {
+      TestRequest request = new TestRequest();
+      CompletableFuture<TestResponse> future = dispatcher.requestUntil(request, 50L, true);
+
+      ExecutionException error = assertThrows(ExecutionException.class,
+         () -> future.get(AWAIT_MS, TimeUnit.MILLISECONDS));
+      assertInstanceOf(TimeoutException.class, error.getCause());
+   }
+
+   @Test
+   void requestUntilResolvesNullOnSoftTimeout() throws Exception {
+      TestRequest request = new TestRequest();
+      CompletableFuture<TestResponse> future = dispatcher.requestUntil(request, 50L, false);
+
+      assertNull(future.get(AWAIT_MS, TimeUnit.MILLISECONDS));
+   }
+
+   @Test
+   void requestUntilNoArgsUsesActionTimeout() throws Exception {
+      TestRequest request = new TestRequest();
+      request.setTimeout(50L);
+
+      assertNull(dispatcher.requestUntil(request).get(AWAIT_MS, TimeUnit.MILLISECONDS));
+   }
+
+   @Test
+   void zeroTimeoutFiresImmediately() {
+      TestRequest request = new TestRequest();
+      CompletableFuture<TestResponse> future = dispatcher.requestUntil(request, 0L, true);
+
+      ExecutionException error = assertThrows(ExecutionException.class,
+         () -> future.get(AWAIT_MS, TimeUnit.MILLISECONDS));
+      assertInstanceOf(TimeoutException.class, error.getCause());
+   }
+
+   @Test
+   void lateResponseWithinGraceHasResponseIdCleared() throws Exception {
+      TestRequest request = new TestRequest();
+      CompletableFuture<TestResponse> future = dispatcher.requestUntil(request, 50L, false);
+      future.get(AWAIT_MS, TimeUnit.MILLISECONDS);
+
+      TestResponse late = new TestResponse(request.getRequestId());
+      dispatcher.dispatch(late);
+
+      assertEquals("", late.getResponseId());
+   }
+
+   @Test
+   void staleMarkerIsCleanedUpAfterGrace() throws Exception {
+      TestableDispatcher fastGraceDispatcher = new TestableDispatcher(50L);
+      fastGraceDispatcher.clientId = "test";
+      fastGraceDispatcher.actionHandlerRegistry = new MapHandlerRegistry();
+      fastGraceDispatcher.clientActionForwarder = new StubForwarder();
+      try {
+         TestRequest request = new TestRequest();
+         fastGraceDispatcher.requestUntil(request, 50L, false).get(AWAIT_MS, TimeUnit.MILLISECONDS);
+
+         // Wait until the grace cleanup actually removed the marker (bounded by AWAIT_MS).
+         long deadline = System.currentTimeMillis() + AWAIT_MS;
+         while (fastGraceDispatcher.requestTimeouts.containsKey(request.getRequestId())
+            && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10);
+         }
+         assertFalse(fastGraceDispatcher.requestTimeouts.containsKey(request.getRequestId()),
+            "Stale marker was not cleaned up within timeout");
+
+         TestResponse late = new TestResponse(request.getRequestId());
+         fastGraceDispatcher.dispatch(late);
+
+         // Marker is gone; responseId must remain so the action follows the normal path.
+         assertEquals(request.getRequestId(), late.getResponseId());
+      } finally {
+         fastGraceDispatcher.dispose();
+      }
+   }
+
+   // -----------------------------------------------------------------------
+   // dispatchAll
+   // -----------------------------------------------------------------------
+
+   @Test
+   void dispatchAllProcessesActionsInOrder() throws Exception {
+      List<String> handled = Collections.synchronizedList(new ArrayList<>());
+      registry.register(MarkerAction.class, new RecordingHandler(MarkerAction.class, action -> {
+         if (action instanceof MarkerAction marker) {
+            handled.add(marker.label);
+         }
+         return List.of();
+      }));
+
+      List<CompletableFuture<Void>> futures = dispatcher.dispatchAll(
+         List.of(new MarkerAction("a"), new MarkerAction("b"), new MarkerAction("c")));
+
+      for (CompletableFuture<Void> future : futures) {
+         future.get(AWAIT_MS, TimeUnit.MILLISECONDS);
+      }
+
+      assertEquals(List.of("a", "b", "c"), handled);
+   }
+
+   @Test
+   void dispatchAllAbortsAfterFailure() throws Exception {
+      List<String> handled = Collections.synchronizedList(new ArrayList<>());
+      registry.register(MarkerAction.class, new RecordingHandler(MarkerAction.class, action -> {
+         if (action instanceof MarkerAction marker) {
+            if (marker.shouldFail) {
+               throw new RuntimeException("boom");
+            }
+            handled.add(marker.label);
+         }
+         return List.of();
+      }));
+
+      MarkerAction first = new MarkerAction("a");
+      MarkerAction failing = new MarkerAction("b", true);
+      MarkerAction third = new MarkerAction("c");
+      List<CompletableFuture<Void>> futures = dispatcher.dispatchAll(List.of(first, failing, third));
+
+      futures.get(0).get(AWAIT_MS, TimeUnit.MILLISECONDS);
+      assertThrows(ExecutionException.class,
+         () -> futures.get(1).get(AWAIT_MS, TimeUnit.MILLISECONDS));
+      assertThrows(ExecutionException.class,
+         () -> futures.get(2).get(AWAIT_MS, TimeUnit.MILLISECONDS));
+
+      assertEquals(List.of("a"), handled);
+   }
+
+   // -----------------------------------------------------------------------
+   // Post-update queue drain
+   // -----------------------------------------------------------------------
+
+   @Test
+   void interceptedSetModelResponseDrainsPostUpdateQueue() throws Exception {
+      List<String> handled = Collections.synchronizedList(new ArrayList<>());
+      CountDownLatch postUpdateLatch = new CountDownLatch(2);
+      registry.register(MarkerAction.class, new RecordingHandler(MarkerAction.class, action -> {
+         if (action instanceof MarkerAction marker) {
+            handled.add(marker.label);
+            postUpdateLatch.countDown();
+         }
+         return List.of();
+      }));
+
+      TestRequest request = new TestRequest();
+      CompletableFuture<TestResponse> future = dispatcher.request(request);
+
+      dispatcher.dispatchAfterNextUpdate(new MarkerAction("post1"), new MarkerAction("post2"));
+
+      SetModelAction response = new SetModelAction();
+      response.setResponseId(request.getRequestId());
+      dispatcher.dispatch(response);
+
+      future.get(AWAIT_MS, TimeUnit.MILLISECONDS);
+      assertTrue(postUpdateLatch.await(AWAIT_MS, TimeUnit.MILLISECONDS),
+         "Post-update actions were not dispatched within timeout");
+      assertEquals(List.of("post1", "post2"), handled);
+   }
+
+   // -----------------------------------------------------------------------
+   // Failure cleanup
+   // -----------------------------------------------------------------------
+
+   @Test
+   void requestRejectsWhenDispatchFails() {
+      // Empty handler registry + forwarder that does NOT handle the action -> dispatch fails.
+      forwarder.shouldHandle = false;
+
+      TestRequest request = new TestRequest();
+      CompletableFuture<TestResponse> future = dispatcher.request(request);
+
+      ExecutionException error = assertThrows(ExecutionException.class,
+         () -> future.get(AWAIT_MS, TimeUnit.MILLISECONDS));
+      assertInstanceOf(IllegalArgumentException.class, error.getCause());
+      assertFalse(dispatcher.pendingRequests.containsKey(request.getRequestId()));
+      assertFalse(dispatcher.requestTimeouts.containsKey(request.getRequestId()));
+   }
+
+   // -----------------------------------------------------------------------
+   // Disposal
+   // -----------------------------------------------------------------------
+
+   @Test
+   void disposeRejectsPendingRequests() {
+      TestRequest request = new TestRequest();
+      CompletableFuture<TestResponse> future = dispatcher.request(request);
+
+      dispatcher.dispose();
+
+      ExecutionException error = assertThrows(ExecutionException.class,
+         () -> future.get(AWAIT_MS, TimeUnit.MILLISECONDS));
+      assertInstanceOf(IllegalStateException.class, error.getCause());
+      assertTrue(error.getCause().getMessage().contains("disposed"));
+   }
+
+   // -----------------------------------------------------------------------
+   // Test fixtures
+   // -----------------------------------------------------------------------
+
+   static final class TestRequest extends RequestAction<TestResponse> {
+      static final String KIND = "test.request";
+
+      TestRequest() {
+         super(KIND);
+      }
+
+      TestRequest(final String requestId) {
+         super(KIND, requestId);
+      }
+   }
+
+   static final class TestResponse extends ResponseAction {
+      static final String KIND = "test.response";
+
+      TestResponse() {
+         super(KIND);
+      }
+
+      TestResponse(final String responseId) {
+         super(KIND);
+         setResponseId(responseId);
+      }
+   }
+
+   static final class TriggerAction extends Action {
+      static final String KIND = "test.trigger";
+
+      TriggerAction() {
+         super(KIND);
+      }
+   }
+
+   static final class MarkerAction extends Action {
+      static final String KIND = "test.marker";
+      final String label;
+      final boolean shouldFail;
+
+      MarkerAction(final String label) {
+         this(label, false);
+      }
+
+      MarkerAction(final String label, final boolean shouldFail) {
+         super(KIND);
+         this.label = label;
+         this.shouldFail = shouldFail;
+      }
+   }
+
+   /**
+    * Forwarder stub that pretends the action is "handled by the client" by default. Set
+    * {@link #shouldHandle} to {@code false} to simulate a forwarder that does not handle the
+    * action (which combined with an empty handler registry causes the dispatch to fail).
+    */
+   static final class StubForwarder extends ClientActionForwarder {
+      List<Action> forwarded = new ArrayList<>();
+      boolean shouldHandle = true;
+
+      @Override
+      public boolean handle(final Action action) {
+         if (!shouldHandle) {
+            return false;
+         }
+         forwarded.add(action);
+         return true;
+      }
+   }
+
+   /** Action handler registry that allows test cases to register handlers for specific kinds. */
+   static final class MapHandlerRegistry implements ActionHandlerRegistry {
+      private final Map<Class<? extends Action>, List<ActionHandler>> handlers = new HashMap<>();
+
+      @Override
+      public boolean register(final Class<? extends Action> key, final ActionHandler element) {
+         handlers.computeIfAbsent(key, k -> new ArrayList<>()).add(element);
+         return true;
+      }
+
+      @Override
+      public boolean deregister(final Class<? extends Action> key, final ActionHandler element) {
+         return handlers.getOrDefault(key, List.of()).remove(element);
+      }
+
+      @Override
+      public boolean deregisterAll(final Class<? extends Action> key) {
+         return handlers.remove(key) != null;
+      }
+
+      @Override
+      public boolean hasKey(final Class<? extends Action> key) {
+         return handlers.containsKey(key);
+      }
+
+      @Override
+      public List<ActionHandler> get(final Class<? extends Action> key) {
+         return handlers.getOrDefault(key, List.of());
+      }
+
+      @Override
+      public List<ActionHandler> getAll() {
+         List<ActionHandler> all = new ArrayList<>();
+         handlers.values().forEach(all::addAll);
+         return all;
+      }
+   }
+
+   /** Simple action handler that records or transforms actions of a given type. */
+   static final class RecordingHandler implements ActionHandler {
+      private final Class<? extends Action> handledType;
+      private final Function<Action, List<Action>> fn;
+
+      RecordingHandler(final Class<? extends Action> handledType, final Function<Action, List<Action>> fn) {
+         this.handledType = handledType;
+         this.fn = fn;
+      }
+
+      @Override
+      public List<Class<? extends Action>> getHandledActionTypes() {
+         return List.of(handledType);
+      }
+
+      @Override
+      public List<Action> execute(final Action action) {
+         return fn.apply(action);
+      }
+   }
+
+   /** Subclass exposing an overridable stale-timeout grace period for fast tests. */
+   static final class TestableDispatcher extends DefaultActionDispatcher {
+      private final long graceMs;
+
+      TestableDispatcher(final long graceMs) {
+         this.graceMs = graceMs;
+      }
+
+      @Override
+      protected long getStaleTimeoutGraceMs() {
+         return graceMs;
+      }
+   }
+}

--- a/tests/org.eclipse.glsp.server.test/src/org/eclipse/glsp/server/internal/actions/DefaultActionDispatcherTest.java
+++ b/tests/org.eclipse.glsp.server.test/src/org/eclipse/glsp/server/internal/actions/DefaultActionDispatcherTest.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -111,7 +112,7 @@ class DefaultActionDispatcherTest {
 
       dispatcher.requestUntil(request, 1234L, false);
 
-      assertEquals(1234L, request.getTimeout());
+      assertEquals(Optional.of(1234L), request.getTimeout());
    }
 
    // -----------------------------------------------------------------------
@@ -166,6 +167,8 @@ class DefaultActionDispatcherTest {
    void reentrantRequestFromHandlerCorrelatesResponse() throws Exception {
       AtomicReference<TestResponse> innerResponse = new AtomicReference<>();
       AtomicReference<Throwable> innerError = new AtomicReference<>();
+      AtomicReference<String> innerRequestId = new AtomicReference<>();
+      CountDownLatch requestRegistered = new CountDownLatch(1);
 
       registry.register(TriggerAction.class, new ActionHandler() {
          @Override
@@ -177,10 +180,11 @@ class DefaultActionDispatcherTest {
          public List<Action> execute(final Action action) {
             TestRequest req = new TestRequest();
             CompletableFuture<TestResponse> future = dispatcher.request(req);
-            // Dispatch the matching response from another thread so the dispatcher thread can
-            // unblock via interceptPendingResponse. The pending future is already registered by
-            // request() so a race-free completion is safe regardless of when this thread runs.
-            new Thread(() -> dispatcher.dispatch(new TestResponse(req.getRequestId()))).start();
+            // Hand the test thread the request id so it can dispatch the matching response.
+            // request() has already registered the pending future, so dispatching the response
+            // from the test thread synchronously completes it via interceptPendingResponse.
+            innerRequestId.set(req.getRequestId());
+            requestRegistered.countDown();
             try {
                innerResponse.set(future.get(AWAIT_MS, TimeUnit.MILLISECONDS));
             } catch (Exception ex) {
@@ -190,7 +194,13 @@ class DefaultActionDispatcherTest {
          }
       });
 
-      dispatcher.dispatch(new TriggerAction()).get(AWAIT_MS, TimeUnit.MILLISECONDS);
+      CompletableFuture<Void> outer = dispatcher.dispatch(new TriggerAction());
+
+      assertTrue(requestRegistered.await(AWAIT_MS, TimeUnit.MILLISECONDS),
+         "Handler did not register the inner request within timeout");
+      dispatcher.dispatch(new TestResponse(innerRequestId.get()));
+
+      outer.get(AWAIT_MS, TimeUnit.MILLISECONDS);
 
       assertNull(innerError.get());
       assertNotNull(innerResponse.get());


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

Enable the server to send requests to the client and await responses, and to issue requests handled locally by server-side handlers.

- Add `request()` and `requestUntil()` to `ActionDispatcher`
- Intercept matching responses in `dispatch()` to resolve pending requests
- Translate `RejectAction` responses to exceptional completion
- Add stale-marker grace cleanup for late-response filtering
- Make `RequestAction.requestId` mutable; add `RequestAction.timeout`
- Add `ResponseAction.hasValidResponseId` utility
- Tighten `ClientActionForwarder` to skip ResponseActions without id
- Handle inbound `RequestAction` in `DefaultGLSPServer.process()`
- Make `dispatchAll` sequential while keeping the list-of-futures API
- Add tests for request/response, timeouts, late responses, and dispose

Relates to https://github.com/eclipse-glsp/glsp/issues/607

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [x] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)

`dispatchAll` executes actions sequentially now and will fail on the first rejected action.