### PR TITLE
Update changelog for v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Changes
 
+### Potentially Breaking Changes
+
+-   [api] Add request/response support to server `ActionDispatcher` [#283](https://github.com/eclipse-glsp/glsp-server/pull/283)
+    -   `dispatchAll` now executes actions sequentially and will fail on the first rejected action
+
 ## [v2.6.0 - 11/02/2026](https://github.com/eclipse-glsp/glsp-server/releases/tag/v2.6.0)
 
 ### Changes


### PR DESCRIPTION
#### What it does

Add changelog entries for v2.7.0 based on merged PRs since v2.6.0.

- Add PR #283 (request/response support for ActionDispatcher) under "Potentially Breaking Changes"

#### How to test

Review the CHANGELOG.md diff for correctness.

#### Follow-ups

None.

#### Changelog

- [ ] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)