### PR TITLE
GLSP-1687: Align protocol actions with glsp-client

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -21,18 +21,20 @@ Run build verification for the Eclipse GLSP server project.
 
 2. **For m2 profile**, run in sequence:
    ```bash
-   mvn clean verify -Pm2 -B
+   mvn clean verify -Pm2 -Pfatjar -B 
    ```
-   This runs compile, checkstyle, and tests together.
+   This runs compile, checkstyle, tests and building of the fatjar together.
 
 3. **For p2 profile**, run:
    ```bash
    mvn clean verify -Pp2 -B
    ```
 
-4. **For fatjar profile**, run:
+4. **For copyright header check**, run:
    ```bash
-   mvn clean verify -Pm2 -Pfatjar -B
+   npx @eclipse-glsp/cli checkHeaders . -f java -e "**/src-gen/**" -a
    ```
-
+   This checks that all Java source files have the correct copyright header, excluding generated sources.
+   Any missing or incorrect headers will be fixed automatically.
+   
 5. **Report results**: summarize pass/fail for each phase (compile, checkstyle, tests). If any step fails, show the relevant error output.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,12 @@
 # AGENTS.md
+
+## Commenting Style
+
+- **Javadoc (`/** ... */`) on the public API**: document `public`/`protected` interfaces, classes, methods, and notable fields. Describe intent and behavior, not the obvious signature. Don't document plain getters/setters.
+- **Cross-reference with `{@link Symbol}`** instead of writing bare type/method names in prose.
+- **Document non-trivial methods** with `@param`/`@return` (and `@throws` where relevant). Skip them for self-explanatory one-liners.
+- **Deprecations** use the fixed form `/** @deprecated Use {@link Replacement} instead */` and pair it with the `@Deprecated` annotation.
+- **Inline `//` comments explain _why_, not _what_** — keep them short and lowercase, and reserve them for non-obvious decisions or rationale.
+- **Mark known limitations** with `// FIXME:` / `// TODO:`, and justify warning suppressions with `@SuppressWarnings("...")` (e.g. `@SuppressWarnings("checkstyle:...")`).
+- Don't restate code in comments; let clear naming carry the _what_.
+- Copyright headers are required on every file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,14 @@
 ## Validation
 
 - After completing any code changes, always run the `/verify` skill before reporting completion
+
+## Commenting Style
+
+- **Javadoc (`/** ... */`) on the public API**: document `public`/`protected` interfaces, classes, methods, and notable fields. Describe intent and behavior, not the obvious signature. Don't document plain getters/setters.
+- **Cross-reference with `{@link Symbol}`** instead of writing bare type/method names in prose.
+- **Document non-trivial methods** with `@param`/`@return` (and `@throws` where relevant). Skip them for self-explanatory one-liners.
+- **Deprecations** use the fixed form `/** @deprecated Use {@link Replacement} instead */` and pair it with the `@Deprecated` annotation.
+- **Inline `//` comments explain _why_, not _what_** — keep them short and lowercase, and reserve them for non-obvious decisions or rationale.
+- **Mark known limitations** with `// FIXME:` / `// TODO:`, and justify warning suppressions with `@SuppressWarnings("...")` (e.g. `@SuppressWarnings("checkstyle:...")`).
+- Don't restate code in comments; let clear naming carry the _what_.
+- Copyright headers are required on every file but are handled by `/verify` — don't add them manually.

--- a/plugins/org.eclipse.glsp.graph/src/org/eclipse/glsp/graph/builder/GShapeElementBuilder.java
+++ b/plugins/org.eclipse.glsp.graph/src/org/eclipse/glsp/graph/builder/GShapeElementBuilder.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/plugins/org.eclipse.glsp.graph/src/org/eclipse/glsp/graph/builder/impl/GLayoutOptions.java
+++ b/plugins/org.eclipse.glsp.graph/src/org/eclipse/glsp/graph/builder/impl/GLayoutOptions.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2021 EclipseSource and others.
+ * Copyright (c) 2019-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/plugins/org.eclipse.glsp.server.websocket/src/org/eclipse/glsp/server/websocket/GLSPServerEndpoint.java
+++ b/plugins/org.eclipse.glsp.server.websocket/src/org/eclipse/glsp/server/websocket/GLSPServerEndpoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2024 EclipseSource and others.
+ * Copyright (c) 2019-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/EditorContextResult.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/EditorContextResult.java
@@ -1,0 +1,47 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.server.actions;
+
+import org.eclipse.glsp.server.types.EditorContext;
+
+/**
+ * Response to a {@link GetEditorContextAction} containing a snapshot of the client-side editor state.
+ *
+ * All fields in the {@link EditorContext} reflect the state at the time of response generation.
+ * The server should not assume that these values are still current when processing the response,
+ * as the client state may have changed in the meantime.
+ */
+public class EditorContextResult extends ResponseAction {
+
+   public static final String KIND = "editorContextResult";
+
+   /** Snapshot of the client-side editor state at the time the response was generated. */
+   private EditorContext editorContext;
+
+   public EditorContextResult() {
+      super(KIND);
+   }
+
+   public EditorContextResult(final EditorContext editorContext) {
+      super(KIND);
+      this.editorContext = editorContext;
+   }
+
+   public EditorContext getEditorContext() { return editorContext; }
+
+   public void setEditorContext(final EditorContext editorContext) { this.editorContext = editorContext; }
+
+}

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/ExportResultAction.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/ExportResultAction.java
@@ -1,0 +1,76 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.server.actions;
+
+import java.util.Optional;
+
+/**
+ * Response to a {@link RequestExportAction} carrying the rendered diagram. Text-encoded
+ * payloads (e.g. SVG markup) ride in {@code data} directly; binary payloads (e.g. PNG) are
+ * base64-encoded with {@code encoding = "base64"} so the action stays JSON-safe.
+ */
+public class ExportResultAction extends ResponseAction {
+
+   public static final String KIND = "exportResult";
+
+   /** Echoes the requested format (e.g. {@code "svg"} or {@code "png"}). */
+   private String format;
+
+   /** MIME type of the exported payload (e.g. {@code "image/svg+xml"} or {@code "image/png"}). */
+   private String mimeType;
+
+   /** Encoding of the bytes carried in {@link #data} (e.g. {@code "text"} or {@code "base64"}). */
+   private String encoding;
+
+   /** SVG markup ({@code encoding = "text"}) or base64-encoded bytes ({@code encoding = "base64"}). */
+   private String data;
+
+   /** Echoes the request's {@code formatOptions} so receivers can correlate result fields back to the request. */
+   private Object formatOptions;
+
+   public ExportResultAction() {
+      super(KIND);
+   }
+
+   public ExportResultAction(final String format, final String data, final String mimeType, final String encoding) {
+      super(KIND);
+      this.format = format;
+      this.data = data;
+      this.mimeType = mimeType;
+      this.encoding = encoding;
+   }
+
+   public String getFormat() { return format; }
+
+   public void setFormat(final String format) { this.format = format; }
+
+   public String getMimeType() { return mimeType; }
+
+   public void setMimeType(final String mimeType) { this.mimeType = mimeType; }
+
+   public String getEncoding() { return encoding; }
+
+   public void setEncoding(final String encoding) { this.encoding = encoding; }
+
+   public String getData() { return data; }
+
+   public void setData(final String data) { this.data = data; }
+
+   public Optional<Object> getFormatOptions() { return Optional.ofNullable(formatOptions); }
+
+   public void setFormatOptions(final Object formatOptions) { this.formatOptions = formatOptions; }
+
+}

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/GetEditorContextAction.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/GetEditorContextAction.java
@@ -1,0 +1,35 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.server.actions;
+
+/**
+ * Sent from the server to the client to request the current editor context. This is the server-initiated
+ * counterpart to the {@code editorContext} that is included in many client-to-server requests.
+ *
+ * All fields in the response represent a snapshot of the client state at the time the response is generated.
+ * There is no guarantee that the state has not changed by the time the server processes the response.
+ *
+ * @see EditorContextResult
+ */
+public class GetEditorContextAction extends RequestAction<EditorContextResult> {
+
+   public static final String KIND = "getEditorContext";
+
+   public GetEditorContextAction() {
+      super(KIND);
+   }
+
+}

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/MoveViewportAction.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/MoveViewportAction.java
@@ -1,0 +1,46 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.server.actions;
+
+/**
+ * Instructs the client to move the diagram canvas by the given amount.
+ */
+public class MoveViewportAction extends Action {
+
+   public static final String KIND = "moveViewport";
+
+   private double moveX;
+   private double moveY;
+
+   public MoveViewportAction() {
+      super(KIND);
+   }
+
+   public MoveViewportAction(final double moveX, final double moveY) {
+      super(KIND);
+      this.moveX = moveX;
+      this.moveY = moveY;
+   }
+
+   public double getMoveX() { return moveX; }
+
+   public void setMoveX(final double moveX) { this.moveX = moveX; }
+
+   public double getMoveY() { return moveY; }
+
+   public void setMoveY(final double moveY) { this.moveY = moveY; }
+
+}

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/OriginViewportAction.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/OriginViewportAction.java
@@ -1,0 +1,40 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.server.actions;
+
+/**
+ * Instructs the client to reset the viewport to its origin (zoom 1, scroll 0).
+ */
+public class OriginViewportAction extends Action {
+
+   public static final String KIND = "originViewport";
+
+   private boolean animate = true;
+
+   public OriginViewportAction() {
+      super(KIND);
+   }
+
+   public OriginViewportAction(final boolean animate) {
+      super(KIND);
+      this.animate = animate;
+   }
+
+   public boolean isAnimate() { return animate; }
+
+   public void setAnimate(final boolean animate) { this.animate = animate; }
+
+}

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/RequestExportAction.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/RequestExportAction.java
@@ -1,0 +1,63 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.server.actions;
+
+import java.util.Optional;
+
+/**
+ * Generic, format-agnostic export request. Sent by the server to the client for server-orchestrated
+ * export flows (e.g. requesting a PNG snapshot of the active diagram). The expected response is an
+ * {@link ExportResultAction} carrying the rendered bytes.
+ *
+ * <p>
+ * The {@code format} identifies the export strategy ({@code "svg"} and {@code "png"} are shipped;
+ * adopters may register additional formats). {@code formatOptions} is opaque to the protocol and is
+ * validated by the {@code DiagramExporter} strategy for the given format.
+ * </p>
+ */
+public class RequestExportAction extends RequestAction<ExportResultAction> {
+
+   public static final String KIND = "requestExport";
+
+   private String format;
+
+   /** Format-specific options interpreted by the export strategy for the given {@link #format}. */
+   private Object formatOptions;
+
+   public RequestExportAction() {
+      super(KIND);
+   }
+
+   public RequestExportAction(final String format) {
+      super(KIND);
+      this.format = format;
+   }
+
+   public RequestExportAction(final String format, final Object formatOptions) {
+      super(KIND);
+      this.format = format;
+      this.formatOptions = formatOptions;
+   }
+
+   public String getFormat() { return format; }
+
+   public void setFormat(final String format) { this.format = format; }
+
+   public Optional<Object> getFormatOptions() { return Optional.ofNullable(formatOptions); }
+
+   public void setFormatOptions(final Object formatOptions) { this.formatOptions = formatOptions; }
+
+}

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/features/core/model/ComputedBoundsAction.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/features/core/model/ComputedBoundsAction.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2022 EclipseSource and others.
+ * Copyright (c) 2019-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/features/core/model/ModelSubmissionHandler.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/features/core/model/ModelSubmissionHandler.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019-2025 EclipseSource and others.
+ * Copyright (c) 2019-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/features/typehints/CheckEdgeResultAction.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/features/typehints/CheckEdgeResultAction.java
@@ -26,7 +26,7 @@ import org.eclipse.glsp.server.actions.ResponseAction;
  */
 public class CheckEdgeResultAction extends ResponseAction {
 
-   public static final String KIND = "checkEdgeResult";
+   public static final String KIND = "checkEdgeTargetResult";
 
    /**
     * true if the selected element is a valid target for this edge,

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operations/LayoutOperation.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/operations/LayoutOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2025 EclipseSource and others.
+ * Copyright (c) 2019-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/types/EditorContext.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/types/EditorContext.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.eclipse.glsp.graph.GBounds;
 import org.eclipse.glsp.graph.GPoint;
 
 /**
@@ -33,6 +34,10 @@ public class EditorContext {
 
    private List<String> selectedElementIds;
    private GPoint lastMousePosition;
+   /** Current scroll position and zoom level of the diagram. */
+   private Viewport viewport;
+   /** Bounds of the diagram canvas DOM element, in browser pixel coordinates. */
+   private GBounds canvasBounds;
    private String sourceUri;
    private Map<String, String> args = new HashMap<>();
 
@@ -47,6 +52,14 @@ public class EditorContext {
    public Optional<GPoint> getLastMousePosition() { return Optional.ofNullable(lastMousePosition); }
 
    public void setLastMousePosition(final GPoint lastMousePosition) { this.lastMousePosition = lastMousePosition; }
+
+   public Optional<Viewport> getViewport() { return Optional.ofNullable(viewport); }
+
+   public void setViewport(final Viewport viewport) { this.viewport = viewport; }
+
+   public Optional<GBounds> getCanvasBounds() { return Optional.ofNullable(canvasBounds); }
+
+   public void setCanvasBounds(final GBounds canvasBounds) { this.canvasBounds = canvasBounds; }
 
    public String getSourceUri() { return sourceUri; }
 


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

Add the protocol actions and editor-context fields introduced in glsp-client since v2.6.0, and register server-initiated response actions dynamically.

- Add MoveViewportAction and OriginViewportAction (server-to-client viewport control)
- Add GetEditorContextAction / EditorContextResult request-response pair
- Add RequestExportAction / ExportResultAction generic export pair
- Add viewport and canvasBounds fields to EditorContext
- Fix CheckEdgeResultAction kind to 'checkEdgeTargetResult'

Also:
- Document the commenting style in CLAUDE.md and AGENTS.md
- Update verify skill to also check copyright headers
- Update copyright headers

Fixes https://github.com/eclipse-glsp/glsp/issues/1687
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [x] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
