### PR TITLE
Update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changes
 
+-   [protocol] Add new viewport, export, and editor-context actions to align with glsp-client [#286](https://github.com/eclipse-glsp/glsp-server/pull/286)
+
 ### Potentially Breaking Changes
 
 -   [api] Add request/response support to server `ActionDispatcher` [#283](https://github.com/eclipse-glsp/glsp-server/pull/283)


### PR DESCRIPTION
#### What it does

Add changelog entries for v2.7.0 based on merged PRs since v2.6.0.

- Add PR [#286](https://github.com/eclipse-glsp/glsp-server/pull/286) (align protocol actions with glsp-client) under "Changes"

#### How to test

Review the CHANGELOG.md diff for correctness.

#### Follow-ups

None.

#### Changelog

- [ ] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)