### PR TITLE
Assign dynamic field in EdgeTypeHint constructor

### DIFF
--- a/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/types/EdgeTypeHint.java
+++ b/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/types/EdgeTypeHint.java
@@ -66,6 +66,7 @@ public class EdgeTypeHint extends ElementTypeHint {
       this.routable = routable;
       this.sourceElementTypeIds = sourceElementTypeIds;
       this.targetElementTypeIds = targetElementTypeIds;
+      this.dynamic = dynamic;
    }
 
    public boolean isRoutable() { return routable; }


### PR DESCRIPTION
Fixes an issue where the dynamic boolean parameter passed into the EdgeTypeHint constructor was ignored.

#### What it does

Fixes [issue #1719](https://github.com/eclipse-glsp/glsp/issues/1719).

#### How to test

1. Create a new EdgeTypeHint that has the parameter `dynamic` set to `true`.
```java
var hint = new EdgeTypeHint(
    elementId,
    true, // repositionable
    true, // deletable
    true, // routable
    true, // dynamic <= was previously ignored
    sourceIds,
    targetIds
);
```
2. Verify that the field was set correctly:
```java
assertTrue(hint.isDynamic());
```

#### Follow-ups

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [ ] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)