### PR TITLE
Release v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Eclipse GLSP Server Changelog
 
-## v2.8.0 - active
+## [v2.8.0 - 31/08/2026](https://github.com/eclipse-glsp/glsp-server/releases/tag/v2.8.0)
 
 ### Changes
 

--- a/examples/org.eclipse.glsp.example.workflow/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.glsp.example.workflow/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GLSP Workflow Example
 Bundle-SymbolicName: org.eclipse.glsp.example.workflow;singleton:=true
-Bundle-Version: 2.8.0.qualifier
+Bundle-Version: 2.8.0
 Bundle-ClassPath: .
 Bundle-Vendor: Eclipse GLSP
 Bundle-Localization: plugin

--- a/examples/org.eclipse.glsp.example.workflow/pom.xml
+++ b/examples/org.eclipse.glsp.example.workflow/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>2.8.0-SNAPSHOT</version>
+		<version>2.8.0</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/plugins/org.eclipse.glsp.graph/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.graph/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GLSP Graph
 Bundle-SymbolicName: org.eclipse.glsp.graph;singleton:=true
-Bundle-Version: 2.8.0.qualifier
+Bundle-Version: 2.8.0
 Bundle-Vendor: Eclipse GLSP
 Automatic-Module-Name: org.eclipse.glsp.graph
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/plugins/org.eclipse.glsp.graph/pom.xml
+++ b/plugins/org.eclipse.glsp.graph/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>2.8.0-SNAPSHOT</version>
+		<version>2.8.0</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/plugins/org.eclipse.glsp.layout/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.layout/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GLSP Layout
 Bundle-SymbolicName: org.eclipse.glsp.layout
-Bundle-Version: 2.8.0.qualifier
+Bundle-Version: 2.8.0
 Bundle-Vendor: EclispeSource
 Automatic-Module-Name: org.eclipse.glsp.layout
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/plugins/org.eclipse.glsp.layout/pom.xml
+++ b/plugins/org.eclipse.glsp.layout/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>2.8.0-SNAPSHOT</version>
+		<version>2.8.0</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/plugins/org.eclipse.glsp.server.emf/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.server.emf/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GLSP Server EMF
 Bundle-SymbolicName: org.eclipse.glsp.server.emf;singleton:=true
-Bundle-Version: 2.8.0.qualifier
+Bundle-Version: 2.8.0
 Bundle-ClassPath: .
 Bundle-Vendor: Eclipse GLSP
 Bundle-Localization: plugin

--- a/plugins/org.eclipse.glsp.server.emf/pom.xml
+++ b/plugins/org.eclipse.glsp.server.emf/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>2.8.0-SNAPSHOT</version>
+		<version>2.8.0</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/plugins/org.eclipse.glsp.server.websocket/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.server.websocket/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GLSP Server Websocket
 Bundle-SymbolicName: org.eclipse.glsp.server.websocket
-Bundle-Version: 2.8.0.qualifier
+Bundle-Version: 2.8.0
 Bundle-Vendor: Eclipse GLSP
 Automatic-Module-Name: com.eclipsesource.glps.server.websocket
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/plugins/org.eclipse.glsp.server.websocket/pom.xml
+++ b/plugins/org.eclipse.glsp.server.websocket/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>2.8.0-SNAPSHOT</version>
+		<version>2.8.0</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/plugins/org.eclipse.glsp.server/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.server/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GLSP Server
 Bundle-SymbolicName: org.eclipse.glsp.server
-Bundle-Version: 2.8.0.qualifier
+Bundle-Version: 2.8.0
 Bundle-Vendor: Eclipse GLSP
 Automatic-Module-Name: org.eclipse.glsp.server
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/plugins/org.eclipse.glsp.server/pom.xml
+++ b/plugins/org.eclipse.glsp.server/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>2.8.0-SNAPSHOT</version>
+		<version>2.8.0</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>org.eclipse.glsp</groupId>
 	<artifactId>org.eclipse.glsp.parent</artifactId>
 	<description>GLSP Parent pom </description>
-	<version>2.8.0-SNAPSHOT</version>
+	<version>2.8.0</version>
 	<packaging>pom</packaging>
 
 	<name>GLSP Parent</name>

--- a/releng/org.eclipse.glsp.feature/feature.xml
+++ b/releng/org.eclipse.glsp.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.glsp.feature"
       label="GLSP SDK (Core)"
-      version="2.8.0.qualifier"
+      version="2.8.0"
       provider-name="Eclipse GLSP">
 
    <description url="http://www.example.com/description">

--- a/releng/org.eclipse.glsp.feature/pom.xml
+++ b/releng/org.eclipse.glsp.feature/pom.xml
@@ -4,7 +4,7 @@
   <parent>
   	<groupId>org.eclipse.glsp</groupId>
   	<artifactId>org.eclipse.glsp.releng</artifactId>
-  	<version>2.8.0-SNAPSHOT</version>
+  	<version>2.8.0</version>
   	<relativePath>../</relativePath>
   </parent>
   <packaging>eclipse-feature</packaging>

--- a/releng/org.eclipse.glsp.repository/pom.xml
+++ b/releng/org.eclipse.glsp.repository/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.releng</artifactId>
-		<version>2.8.0-SNAPSHOT</version>
+		<version>2.8.0</version>
 		<relativePath>../</relativePath>
 	</parent>
 	<artifactId>org.eclipse.glsp.repository</artifactId>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>2.8.0-SNAPSHOT</version>
+		<version>2.8.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/tests/org.eclipse.glsp.graph.test/pom.xml
+++ b/tests/org.eclipse.glsp.graph.test/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>2.8.0-SNAPSHOT</version>
+		<version>2.8.0</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/tests/org.eclipse.glsp.server.test/pom.xml
+++ b/tests/org.eclipse.glsp.server.test/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>2.8.0-SNAPSHOT</version>
+		<version>2.8.0</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.eclipse.glsp</groupId>
 		<artifactId>org.eclipse.glsp.parent</artifactId>
-		<version>2.8.0-SNAPSHOT</version>
+		<version>2.8.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 


### PR DESCRIPTION
Prepare release v2.8.0

## Changes

### Potentially Breaking Changes

- [layout] Keep applying computed bounds when an individual entry cannot be applied [#295](https://github.com/eclipse-glsp/glsp-server/pull/295)
    - `LayoutUtil.applyRoute` now returns `Optional<GEdge>` instead of `GEdge`
    - `LayoutUtil.applyBounds`, `applyAlignment` and `applyRoute` no longer throw for an element the index cannot resolve, they report it as not applied. `applyRoutingPoints` stays strict.
    - `ComputedBoundsActionHandler` applies the computed bounds through the new overridable `applyBounds`, `applyElementBounds`, `applyAlignments` and `applyRoutes` methods, so adjusting one kind no longer means taking over `executeAction` and its model lock
    - `LayoutUtil.applyBounds(GModelRoot, ComputedBoundsAction, GModelState)` is deprecated. It dispatches to the static per-kind methods directly and therefore bypasses the overridable ones of `ComputedBoundsActionHandler`.

**Full Changelog**: https://github.com/eclipse-glsp/glsp-server/compare/v2.7.0...v2.8.0


Note: This pull request was created automatically. After merging, the automated publishing process will be started.
